### PR TITLE
Undefined should rarely appear in code or json

### DIFF
--- a/client/src/components/author/category-list-item.tsx
+++ b/client/src/components/author/category-list-item.tsx
@@ -25,7 +25,7 @@ import QuestionListItem from "./question-list-item";
 export function CategoryListItem(props: {
   category: Category;
   questions: SubjectQuestion[];
-  selectedQuestion: string | undefined;
+  selectedQuestion?: string;
   removeCategory: (val: Category) => void;
   updateCategory: (newVal: Category) => void;
   updateQuestion: (newVal: SubjectQuestion) => void;

--- a/client/src/components/author/question-edit.tsx
+++ b/client/src/components/author/question-edit.tsx
@@ -28,7 +28,7 @@ import TopicsList from "components/author/question-topics-list";
 
 export function QuestionEditCard(props: {
   classes: Record<string, string>;
-  question: SubjectQuestion | undefined;
+  question?: SubjectQuestion;
   topics: Topic[];
   updateQuestion: (val: SubjectQuestion) => void;
   onDeselect: () => void;

--- a/client/src/components/author/questions-list.tsx
+++ b/client/src/components/author/questions-list.tsx
@@ -43,11 +43,7 @@ export function QuestionsList(props: {
   addQuestion: () => void;
   editQuestion: (val: SubjectQuestion) => void;
   removeQuestion: (val: SubjectQuestion) => void;
-  moveQuestion: (
-    toMove: string,
-    moveTo: string | undefined,
-    category: string | undefined
-  ) => void;
+  moveQuestion: (toMove: string, moveTo?: string, category?: string) => void;
 }): JSX.Element {
   const { classes, maxHeight, expanded, questions, toggleExpanded } = props;
   const [selectedQuestion, setSelectedQuestion] = useState<string>();

--- a/client/src/components/dialog.tsx
+++ b/client/src/components/dialog.tsx
@@ -16,7 +16,7 @@ import {
 import { LoadingError } from "hooks/graphql/loading-reducer";
 
 export function ErrorDialog(props: {
-  error: LoadingError | undefined;
+  error?: LoadingError;
   clearError?: () => void;
 }): JSX.Element {
   const { error, clearError } = props;

--- a/client/src/components/my-mentor-card/use-with-recommended-action.tsx
+++ b/client/src/components/my-mentor-card/use-with-recommended-action.tsx
@@ -28,14 +28,14 @@ interface Category {
 
 interface Conditions {
   mentorId: string;
-  idle: Answer | undefined;
+  idle?: Answer;
   idleIncomplete: boolean;
   isVideo: boolean;
   hasThumbnail: boolean;
   isDirty: boolean;
   categories: Category[];
-  incompleteRequirement: Category | undefined;
-  firstIncomplete: Category | undefined;
+  incompleteRequirement?: Category;
+  firstIncomplete?: Category;
   completedAnswers: number;
   totalAnswers: number;
 }

--- a/client/src/components/record/follow-up-question-list.tsx
+++ b/client/src/components/record/follow-up-question-list.tsx
@@ -19,7 +19,7 @@ function FollowUpQuestionsWidget(props: {
   mentorId: string;
   addQuestion: (q: NewQuestionArgs) => void;
   removeQuestion: (val: SubjectQuestion) => void;
-  editedData: Subject | undefined;
+  editedData?: Subject;
   toRecordFollowUpQs: (b: boolean) => void;
 }): JSX.Element {
   const [seeAll, setSeeAll] = useState(false);

--- a/client/src/components/record/video-player.tsx
+++ b/client/src/components/record/video-player.tsx
@@ -250,12 +250,15 @@ function VideoPlayer(props: {
             onClick={() => {
               if (isUploading) {
                 recordState.cancelUpload(upload!);
-              } else if (isTrimming) {
-                const trimStart = (trim[0] / 100) * videoLength;
-                const trimEnd = (trim[1] / 100) * videoLength;
-                recordState.uploadVideo({ start: trimStart, end: trimEnd });
               } else {
-                recordState.uploadVideo();
+                recordState.uploadVideo(
+                  isTrimming
+                    ? {
+                        start: (trim[0] / 100) * videoLength,
+                        end: (trim[1] / 100) * videoLength,
+                      }
+                    : undefined
+                );
               }
             }}
             style={{ marginRight: 15 }}

--- a/client/src/components/setup/mentor-info-slide.tsx
+++ b/client/src/components/setup/mentor-info-slide.tsx
@@ -11,7 +11,7 @@ import { Slide } from "./slide";
 
 export function MentorInfoSlide(props: {
   classes: Record<string, string>;
-  mentor: Mentor | undefined;
+  mentor?: Mentor;
   isMentorLoading: boolean;
   editMentor: (edits: Partial<Mentor>) => void;
 }): JSX.Element {

--- a/client/src/components/setup/mentor-type-slide.tsx
+++ b/client/src/components/setup/mentor-type-slide.tsx
@@ -11,7 +11,7 @@ import { Slide } from "./slide";
 
 export function MentorTypeSlide(props: {
   classes: Record<string, string>;
-  mentor: Mentor | undefined;
+  mentor?: Mentor;
   isMentorLoading: boolean;
   editMentor: (edits: Partial<Mentor>) => void;
 }): JSX.Element {
@@ -33,7 +33,7 @@ export function MentorTypeSlide(props: {
             style={{ width: 100, marginRight: 20 }}
             onChange={(
               event: React.ChangeEvent<{
-                name?: string | undefined;
+                name?: string;
                 value: unknown;
               }>
             ) => {

--- a/client/src/hooks/graphql/recording-reducer.tsx
+++ b/client/src/hooks/graphql/recording-reducer.tsx
@@ -13,12 +13,12 @@ export interface RecordingError {
 export interface RecordingState {
   isSaving: boolean;
   isRecording: boolean;
-  error: RecordingError | undefined;
+  error?: RecordingError;
 }
 
 export interface RecordingAction {
   type: RecordingActionType;
-  payload: boolean | RecordingError | undefined;
+  payload?: boolean | RecordingError;
 }
 
 export enum RecordingActionType {

--- a/client/src/hooks/graphql/use-with-data-connection.ts
+++ b/client/src/hooks/graphql/use-with-data-connection.ts
@@ -19,8 +19,8 @@ export interface SearchParams {
 }
 
 export interface UseDataConnection<T> {
-  data: Connection<T> | undefined;
-  error: LoadingError | undefined;
+  data?: Connection<T>;
+  error?: LoadingError;
   isLoading: boolean;
   searchParams: SearchParams;
   editData: (edits: Partial<T>) => void;

--- a/client/src/hooks/graphql/use-with-data.tsx
+++ b/client/src/hooks/graphql/use-with-data.tsx
@@ -24,12 +24,12 @@ export interface UpdateFunc<T> {
 }
 
 export interface UseData<T> {
-  data: T | undefined;
-  editedData: T | undefined;
+  data?: T;
+  editedData?: T;
   isEdited: boolean;
   isLoading: boolean;
   isSaving: boolean;
-  error: LoadingError | undefined;
+  error?: LoadingError;
   reloadData: () => void;
   editData: (d: Partial<T>) => void;
   saveData: (action: UpdateFunc<T>) => Promise<void>;

--- a/client/src/hooks/graphql/use-with-record-state.tsx
+++ b/client/src/hooks/graphql/use-with-record-state.tsx
@@ -33,7 +33,7 @@ export interface CurAnswerState extends AnswerState {
   isEdited: boolean;
   isValid: boolean;
   isUploading: boolean;
-  videoSrc: string | undefined;
+  videoSrc?: string;
 }
 
 export function useWithRecordState(
@@ -397,11 +397,11 @@ export function useWithRecordState(
 }
 
 export interface UseWithRecordState {
-  mentor: Mentor | undefined;
+  mentor?: Mentor;
   answers: AnswerState[];
   answerIdx: number;
   recordPageState: RecordPageState;
-  curAnswer: CurAnswerState | undefined;
+  curAnswer?: CurAnswerState;
   uploads: UploadTask[];
   pollStatusCount: number;
   followUpQuestions: string[];
@@ -417,19 +417,12 @@ export interface UseWithRecordState {
   rerecord: () => void;
   startRecording: () => void;
   stopRecording: (video: File) => void;
-  uploadVideo: (
-    trim?:
-      | {
-          start: number;
-          end: number;
-        }
-      | undefined
-  ) => void;
+  uploadVideo: (trim?: { start: number; end: number }) => void;
   cancelUpload: (task: UploadTask) => void;
   setMinVideoLength: (length: number) => void;
   isUploading: boolean;
   isRecording: boolean;
   isSaving: boolean;
-  error: RecordingError | undefined;
+  error?: RecordingError;
   clearError: () => void;
 }

--- a/client/src/hooks/graphql/use-with-review-answer-state.tsx
+++ b/client/src/hooks/graphql/use-with-review-answer-state.tsx
@@ -203,11 +203,11 @@ export function useWithReviewAnswerState(
     );
   }
 
-  function selectSubject(sId: string | undefined) {
-    setSelectedSubject(sId);
+  function selectSubject(sId?: string) {
+    setSelectedSubject(sId || "");
   }
 
-  function addNewQuestion(subject: Subject, category: Category | undefined) {
+  function addNewQuestion(subject: Subject, category?: Category) {
     if (!editedMentor || isMentorLoading || isSaving) {
       return;
     }
@@ -335,17 +335,17 @@ export function useWithReviewAnswerState(
 }
 
 interface UseWithReviewAnswerState {
-  mentor: Mentor | undefined;
+  mentor?: Mentor;
   isMentorEdited: boolean;
   blocks: RecordingBlock[];
   progress: Progress;
-  selectedSubject: string | undefined;
+  selectedSubject?: string;
   isLoading: boolean;
   isSaving: boolean;
   isTraining: boolean;
-  error: LoadingError | undefined;
+  error?: LoadingError;
   clearError: () => void;
-  selectSubject: (sId: string | undefined) => void;
+  selectSubject: (sId?: string) => void;
   saveChanges: () => void;
   startTraining: (params: string) => void;
 }

--- a/client/src/hooks/graphql/use-with-setup.tsx
+++ b/client/src/hooks/graphql/use-with-setup.tsx
@@ -37,12 +37,10 @@ interface SetupStep {
 interface SetupStatus {
   isMentorInfoDone: boolean;
   isMentorTypeChosen: boolean;
-  idle:
-    | {
-        idle: Answer;
-        complete: boolean;
-      }
-    | undefined;
+  idle?: {
+    idle: Answer;
+    complete: boolean;
+  };
   requiredSubjects: {
     subject: Subject;
     answers: Answer[];
@@ -54,15 +52,15 @@ interface SetupStatus {
 }
 
 interface UseWithSetup {
-  setupStatus: SetupStatus | undefined;
+  setupStatus?: SetupStatus;
   setupStep: number;
   setupSteps: SetupStep[];
-  mentor: Mentor | undefined;
+  mentor?: Mentor;
   isEdited: boolean;
   isLoading: boolean;
   isSaving: boolean;
   isTraining: boolean;
-  error: LoadingError | undefined;
+  error?: LoadingError;
   editMentor: (d: Partial<Mentor>) => void;
   saveMentor: () => void;
   startTraining: () => void;

--- a/client/src/hooks/graphql/use-with-subject.tsx
+++ b/client/src/hooks/graphql/use-with-subject.tsx
@@ -29,11 +29,7 @@ interface UseWithSubject extends UseData<Subject> {
   addQuestion: (q?: NewQuestionArgs) => void;
   updateQuestion: (val: SubjectQuestion) => void;
   removeQuestion: (val: SubjectQuestion) => void;
-  moveQuestion: (
-    toMove: string,
-    moveTo: string | undefined,
-    category: string | undefined
-  ) => void;
+  moveQuestion: (toMove: string, moveTo?: string, category?: string) => void;
 }
 
 export function useWithSubject(
@@ -218,11 +214,7 @@ export function useWithSubject(
     }
   }
 
-  function moveQuestion(
-    toMove: string,
-    moveTo: string | undefined,
-    category: string | undefined
-  ) {
+  function moveQuestion(toMove: string, moveTo?: string, category?: string) {
     if (!editedData) {
       return;
     }

--- a/client/src/hooks/task/task-reducer.tsx
+++ b/client/src/hooks/task/task-reducer.tsx
@@ -12,12 +12,12 @@ export interface TaskError {
 
 export interface TaskState {
   isPolling: boolean;
-  error: TaskError | undefined;
+  error?: TaskError;
 }
 
 export interface TaskAction {
   type: TaskActionType;
-  payload: boolean | TaskError | undefined;
+  payload?: boolean | TaskError;
 }
 
 export enum TaskActionType {

--- a/client/src/hooks/task/use-with-task.tsx
+++ b/client/src/hooks/task/use-with-task.tsx
@@ -22,9 +22,9 @@ const initialState: TaskState = {
 
 export interface Task<T, U> {
   isPolling: boolean;
-  error: TaskError | undefined;
-  status: TaskStatus<T> | undefined;
-  statusUrl: string | undefined;
+  error?: TaskError;
+  status?: TaskStatus<T>;
+  statusUrl?: string;
   startTask: (params: U) => void;
   clearError: () => void;
 }

--- a/client/src/pages/feedback.tsx
+++ b/client/src/pages/feedback.tsx
@@ -121,13 +121,13 @@ const columnHeaders: ColumnDef[] = [
 
 function FeedbackItem(props: {
   feedback: UserQuestion;
-  mentor: Mentor | undefined;
+  mentor?: Mentor;
   onUpdated: () => void;
 }): JSX.Element {
   const { feedback, mentor, onUpdated } = props;
 
   // TODO: MOVE THIS TO A HOOK
-  async function onUpdateAnswer(answerId: string | undefined) {
+  async function onUpdateAnswer(answerId?: string) {
     await updateUserQuestion(feedback._id, answerId || "");
     onUpdated();
   }

--- a/client/src/store/slices/config/index.ts
+++ b/client/src/store/slices/config/index.ts
@@ -16,12 +16,11 @@ export enum ConfigStatus {
 }
 
 export interface ConfigState {
-  config: Config | undefined;
+  config?: Config;
   status: ConfigStatus;
 }
 
 const initialState: ConfigState = {
-  config: undefined,
   status: ConfigStatus.NONE,
 };
 

--- a/client/src/store/slices/login/index.ts
+++ b/client/src/store/slices/login/index.ts
@@ -19,15 +19,14 @@ export enum LoginStatus {
 }
 
 export interface LoginState {
-  accessToken: string | undefined;
+  accessToken?: string;
   loginStatus: LoginStatus;
-  user: User | undefined;
+  user?: User;
 }
 
 const initialState: LoginState = {
   accessToken: undefined,
   loginStatus: LoginStatus.NONE,
-  user: undefined,
 };
 
 /** Actions */


### PR DESCRIPTION
The code base is full of `undefined` as a type, and we should almost NEVER use it explicitly.

The most common error is reinventing the typescript optional type, e.g.

```typescript
interface Foo {
  bad: string | undefined;
  good?: string
}

function bad(foo: string | undefined) {}

function good(foo?: string) {}
```

...also special not about strings which may be unset. When it's not too much of a hassel, retain the type string and don't allow it to be optional...just use the empty string to mean unset. This is sometimes a pain if it means you have to define a bunch of properties in objects with empty string, so not always required