### PR TITLE
Temporary fix for mentor bug:

### DIFF
--- a/client/src/components/home/index.tsx
+++ b/client/src/components/home/index.tsx
@@ -73,9 +73,7 @@ function HomePage(props: {
 }): JSX.Element {
   const classes = useStyles();
   const {
-    mentor,
-    isLoading,
-    isMentorEdited,
+    useMentor,
     selectedSubject,
     blocks,
     progress,
@@ -86,6 +84,7 @@ function HomePage(props: {
     saveChanges,
     startTraining,
   } = useWithReviewAnswerState(props.accessToken, props.search);
+  const { data: mentor, isLoading, isEdited: isMentorEdited } = useMentor;
 
   if (!mentor) {
     return (
@@ -110,6 +109,7 @@ function HomePage(props: {
         <MyMentorCard
           accessToken={props.accessToken}
           continueAction={continueAction}
+          useWithMentor={useMentor}
         />
         <Select
           data-cy="select-subject"

--- a/client/src/components/my-mentor-card/index.tsx
+++ b/client/src/components/my-mentor-card/index.tsx
@@ -29,8 +29,7 @@ import StageProgress from "./stage-progress";
 import parseMentor from "./mentor-info";
 import { ErrorDialog, LoadingDialog } from "components/dialog";
 import { MentorType } from "types";
-import { useActiveMentor } from "store/slices/mentor/useActiveMentor";
-import { MentorStatus } from "store/slices/mentor";
+import { UseMentorData } from "hooks/graphql/use-with-mentor";
 
 const useStyles = makeStyles(() => ({
   homeThumbnail: {
@@ -53,18 +52,26 @@ const useStyles = makeStyles(() => ({
 export default function MyMentorCard(props: {
   accessToken: string;
   continueAction: () => void;
+  useWithMentor: UseMentorData;
 }): JSX.Element {
-  const { mentorState, editMentor } = useActiveMentor();
+  const {
+    data,
+    editedData,
+    editData: editMentor,
+    isLoading,
+    isSaving,
+    error,
+  } = props.useWithMentor;
 
-  if (!mentorState.data || !mentorState.editedData) {
+  if (!data || !editedData) {
     return <div />;
   }
-  const mentorInfo = parseMentor(mentorState.data);
+  const mentorInfo = parseMentor(data);
   const classes = useStyles();
   const [thumbnail, updateThumbnail] = useWithThumbnail(
-    mentorState.data._id,
+    data._id,
     props.accessToken,
-    mentorState.data.thumbnail || ""
+    data.thumbnail || ""
   );
 
   return (
@@ -83,14 +90,14 @@ export default function MyMentorCard(props: {
               <TextField
                 data-cy="mentor-name"
                 label="Full Name"
-                value={mentorState.editedData.name}
+                value={editedData.name}
                 onChange={(e) => editMentor({ name: e.target.value })}
                 className={classes.inputField}
               />
               <TextField
                 data-cy="mentor-job-title"
                 label="Job Title"
-                value={mentorState.editedData.title}
+                value={editedData.title}
                 onChange={(e) => editMentor({ title: e.target.value })}
                 className={classes.inputField}
               />
@@ -131,7 +138,7 @@ export default function MyMentorCard(props: {
               <TextField
                 data-cy="mentor-first-name"
                 label="First Name"
-                value={mentorState.editedData.firstName}
+                value={editedData.firstName}
                 onChange={(e) => editMentor({ firstName: e.target.value })}
                 className={classes.inputField}
               />
@@ -139,17 +146,17 @@ export default function MyMentorCard(props: {
                 data-cy="mentor-email"
                 label="Email"
                 type="email"
-                value={mentorState.editedData.email}
+                value={editedData.email}
                 onChange={(e) => editMentor({ email: e.target.value })}
                 className={classes.inputField}
               />
               <FormControlLabel
                 control={
                   <Checkbox
-                    checked={mentorState.editedData.allowContact}
+                    checked={editedData.allowContact}
                     onChange={() =>
                       editMentor({
-                        allowContact: !mentorState.editedData?.allowContact,
+                        allowContact: !editedData?.allowContact,
                       })
                     }
                     color="secondary"
@@ -164,7 +171,7 @@ export default function MyMentorCard(props: {
                   <Select
                     data-cy="select-chat-type"
                     label="Mentor Type"
-                    value={mentorState.editedData.mentorType}
+                    value={editedData.mentorType}
                     style={{ width: 200 }}
                     onChange={(
                       event: React.ChangeEvent<{
@@ -250,7 +257,7 @@ export default function MyMentorCard(props: {
             </Grid>
             <Grid xs={12} md={2}>
               <RecommendedActionButton
-                mentor={mentorState.data}
+                mentor={data}
                 setThumbnail={updateThumbnail}
                 continueAction={props.continueAction}
               />
@@ -263,16 +270,8 @@ export default function MyMentorCard(props: {
         floor={mentorInfo.currentStage.floor}
         name={mentorInfo.currentStage.name}
       />
-      <LoadingDialog
-        title={
-          mentorState.mentorStatus === MentorStatus.LOADING
-            ? "Loading"
-            : mentorState.mentorStatus === MentorStatus.SAVING
-            ? "Saving"
-            : ""
-        }
-      />
-      <ErrorDialog error={mentorState.error} />
+      <LoadingDialog title={isLoading ? "Loading" : isSaving ? "Saving" : ""} />
+      <ErrorDialog error={error} />
     </div>
   );
 }

--- a/client/src/hooks/graphql/use-with-import-export.tsx
+++ b/client/src/hooks/graphql/use-with-import-export.tsx
@@ -13,8 +13,8 @@ import {
   Question,
   Subject,
 } from "types";
-import { useActiveMentor } from "store/slices/mentor/useActiveMentor";
 import { copyAndRemove, copyAndSet } from "helpers";
+import { useWithMentor } from "./use-with-mentor";
 
 export interface UseWithImportExport {
   mentor: Mentor | undefined;
@@ -32,8 +32,7 @@ export function useWithImportExport(accessToken: string): UseWithImportExport {
   const [importedJson, setImportJson] = useState<MentorExportJson>();
   const [importPreview, setImportPreview] = useState<MentorImportPreview>();
   const [isUpdating, setIsUpdating] = useState(false);
-  const { mentorState } = useActiveMentor();
-  const mentor = mentorState.data;
+  const { data: mentor } = useWithMentor(accessToken);
 
   function onMentorExported(): void {
     if (!mentor || isUpdating) {

--- a/client/src/hooks/graphql/use-with-mentor.tsx
+++ b/client/src/hooks/graphql/use-with-mentor.tsx
@@ -8,7 +8,7 @@ import { fetchMentor, updateMentorDetails, updateMentorSubjects } from "api";
 import { Mentor } from "types";
 import { UseData, useWithData } from "./use-with-data";
 
-interface UseMentorData extends UseData<Mentor> {
+export interface UseMentorData extends UseData<Mentor> {
   saveMentorDetails: () => void;
   saveMentorSubjects: () => void;
 }

--- a/client/src/hooks/graphql/use-with-record-state.tsx
+++ b/client/src/hooks/graphql/use-with-record-state.tsx
@@ -17,11 +17,10 @@ import {
 } from "types";
 import { copyAndSet, equals } from "helpers";
 
+import { RecordPageState } from "types";
+import { useWithMentor } from "./use-with-mentor";
 import { UploadTask, useWithUploadStatus } from "./use-with-upload-status";
 import { RecordingError } from "./recording-reducer";
-import { RecordPageState } from "types";
-import { useActiveMentor } from "store/slices/mentor/useActiveMentor";
-import { MentorStatus } from "store/slices/mentor";
 
 export interface AnswerState {
   answer: Answer;
@@ -58,7 +57,12 @@ export function useWithRecordState(
   const [error, setError] = useState<RecordingError>();
   const [followUpQuestions, setFollowUpQuestions] = useState<string[]>([]);
   const pollingInterval = parseInt(filter.poll || "");
-  const { mentorState, loadMentor } = useActiveMentor();
+  const {
+    data: mentor,
+    error: mentorError,
+    isLoading: isMentorLoading,
+    reloadData: loadMentor,
+  } = useWithMentor(accessToken);
 
   const {
     uploads,
@@ -73,12 +77,8 @@ export function useWithRecordState(
     onAnswerUploaded,
     isNaN(pollingInterval) ? undefined : pollingInterval
   );
-  const mentorError = mentorState.error;
-  const mentor = mentorState.data;
-  const isMentorLoading = mentorState.mentorStatus === MentorStatus.LOADING;
 
   useEffect(() => {
-    const mentor = mentorState.data;
     if (!mentor) {
       return;
     }

--- a/client/src/hooks/graphql/use-with-review-answer-state.tsx
+++ b/client/src/hooks/graphql/use-with-review-answer-state.tsx
@@ -16,14 +16,12 @@ import {
   SubjectQuestion,
   QuestionType,
   Question,
-  Mentor,
   UtteranceName,
 } from "types";
 import { copyAndSet, equals, urlBuild } from "helpers";
 import { useWithTraining } from "hooks/task/use-with-train";
 import { LoadingError } from "./loading-reducer";
-import { useActiveMentor } from "store/slices/mentor/useActiveMentor";
-import { MentorStatus } from "store/slices/mentor";
+import { UseMentorData, useWithMentor } from "./use-with-mentor";
 
 interface Progress {
   complete: number;
@@ -52,21 +50,21 @@ export function useWithReviewAnswerState(
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [error, setError] = useState<LoadingError>();
   const {
-    mentorState,
-    editMentor,
-    loadMentor: reloadMentor,
-    saveMentor,
-  } = useActiveMentor();
-  const mentorError = mentorState.error;
-  const mentor = mentorState.data;
-  const editedMentor = mentorState.editedData;
-  const isMentorLoading = mentorState.mentorStatus === MentorStatus.LOADING;
-  const {
     isPolling: isTraining,
     error: trainError,
     startTask: startTraining,
     clearError: clearTrainingError,
   } = useWithTraining();
+  const useMentor = useWithMentor(accessToken);
+  const {
+    data: mentor,
+    editedData: editedMentor,
+    reloadData: reloadMentor,
+    error: mentorError,
+    isLoading: isMentorLoading,
+    editData: editMentor,
+    isEdited: isMentorEdited,
+  } = useMentor;
 
   useEffect(() => {
     if (!editedMentor || isMentorLoading || isSaving) {
@@ -299,7 +297,7 @@ export function useWithReviewAnswerState(
     if (
       !mentor ||
       !editedMentor ||
-      !mentorState.isEdited ||
+      !isMentorEdited ||
       isMentorLoading ||
       isSaving
     ) {
@@ -317,7 +315,6 @@ export function useWithReviewAnswerState(
         })
     )
       .then(() => {
-        saveMentor();
         reloadMentor();
         setIsSaving(false);
       })
@@ -329,12 +326,10 @@ export function useWithReviewAnswerState(
   }
 
   return {
-    mentor,
-    isMentorEdited: Boolean(mentorState.isEdited),
+    useMentor,
     blocks,
     progress,
     selectedSubject,
-    isLoading: isMentorLoading,
     isSaving,
     isTraining,
     error,
@@ -346,12 +341,10 @@ export function useWithReviewAnswerState(
 }
 
 interface UseWithReviewAnswerState {
-  mentor?: Mentor;
-  isMentorEdited: boolean;
+  useMentor: UseMentorData;
   blocks: RecordingBlock[];
   progress: Progress;
   selectedSubject?: string;
-  isLoading: boolean;
   isSaving: boolean;
   isTraining: boolean;
   error?: LoadingError;


### PR DESCRIPTION
- go to back to using state instead of redux

This is a temporary fix for the mentor reload bug that goes to back to the old useWithMentor instead of useActiveMentor.
This fixes the need to reload the page to see mentor updates for everything *but* editing the mentor details on the my mentor page card, which does not save changes
However, the user can still edit their name/email/title from the setup card