### PR TITLE
Fix scrollbar missing after opening Select Subject dropdown

### DIFF
--- a/client/src/components/home/index.tsx
+++ b/client/src/components/home/index.tsx
@@ -222,7 +222,7 @@ function HomePage(props: {
         data-cy="setup-dialog"
         maxWidth="sm"
         fullWidth={true}
-        open={setupStatus && showSetupAlert}
+        open={setupStatus && !setupStatus.isSetupComplete && showSetupAlert}
         onClose={() => setShowSetupAlert(false)}
       >
         <DialogTitle data-cy="setup-dialog-title">Finish Setup?</DialogTitle>


### PR DESCRIPTION
This was a strange bug.

I noticed that whenever a modal component would render (hamburger menu, select subjects dropdown, Dialog component, etc), it would get rid of the main pages scrollbar for the duration that it is open. The expected behavior is that once you close the modal, the scrollbar returns, but it did not.

The cause of this bug was due to the "setup-dialog" Dialog component unnecessarily opening and then closing when first visiting MentorStudio for mentors that never needed it open in the first place. (Not sure if the Dialog was somehow stuck open in the background or something?)

The fix was just making sure the Dialog component never opened unless the setupStatus was loaded and we were sure that the isSetupComplete === false