### PR TITLE
Import export update

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -957,6 +957,25 @@ export async function updateAnswer(
   );
 }
 
+export async function deleteImportTask(
+  accessToken: string,
+  mentorId: string
+): Promise<boolean> {
+  return execGql<boolean>(
+    {
+      query: `
+        mutation ImportTaskDelete($mentorId: ID!){
+          me{
+            importTaskDelete(mentorId:$mentorId)
+          }
+        }
+      `,
+      variables: { mentorId },
+    },
+    { accessToken, dataPath: ["me", "importTaskDelete"] }
+  );
+}
+
 export async function trainMentor(mentorId: string): Promise<AsyncJob> {
   return execHttp("POST", urljoin(CLASSIFIER_ENTRYPOINT, "train"), {
     axiosConfig: {

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1332,6 +1332,33 @@ export async function exportMentor(mentor: string): Promise<MentorExportJson> {
                 minVideoLength
               }
             }
+            userQuestions{
+              _id
+              question
+              confidence
+              classifierAnswerType
+              feedback
+              mentor{
+                _id
+                name
+              }
+              classifierAnswer{
+                _id
+                question{
+                  _id
+                  question
+                }
+                transcript
+              }
+              graderAnswer{
+                _id
+                question{
+                  _id
+                  question
+                }
+                transcript
+              }
+            }
           }
         }
       `,

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -73,7 +73,7 @@ function isValidObjectID(id: string) {
   return id.match(/^[0-9a-fA-F]{24}$/);
 }
 
-const REQUEST_TIMEOUT_GRAPHQL_DEFAULT = 60000;
+const REQUEST_TIMEOUT_GRAPHQL_DEFAULT = 30000;
 
 /**
  * Middleware function takes some action on an axios instance
@@ -1540,106 +1540,6 @@ export async function fetchImportTask(
 }
 
 export async function importMentor(
-  mentor: string,
-  json: MentorExportJson,
-  accessToken: string
-): Promise<MentorGQL> {
-  return execGql<MentorGQL>(
-    {
-      query: `
-        mutation MentorImport($mentor: ID!, $json: MentorImportJsonType!) {
-          me {
-            mentorImport(mentor: $mentor, json: $json) {
-              _id
-              name
-              firstName
-              title
-              email
-              allowContact
-              mentorType
-              thumbnail
-              lastTrainedAt
-              isDirty
-              defaultSubject {
-                _id
-              }
-              subjects {
-                _id
-                name
-                description
-                isRequired
-                categories {
-                  id
-                  name
-                  description
-                }
-                topics {
-                  id
-                  name
-                  description
-                }
-                questions {
-                  question {
-                    _id
-                    question
-                    type
-                    name
-                    paraphrases
-                    mentor
-                    mentorType
-                    minVideoLength
-                  }
-                  category {
-                    id
-                    name
-                    description
-                  }
-                  topics {
-                    id
-                    name
-                    description
-                  }
-                }
-              }
-              topics {
-                id
-                name
-                description
-              }
-              answers {
-                _id
-                question {
-                  _id
-                  question
-                  paraphrases
-                  type
-                  name
-                  mentor
-                  mentorType
-                  minVideoLength
-                }
-                transcript
-                status
-                hasEditedTranscript
-                hasUntransferredMedia
-                media {
-                  type
-                  tag
-                  url
-                  needsTransfer
-                }
-              }
-            }
-          }
-        }
-      `,
-      variables: { mentor, json },
-    },
-    { accessToken, dataPath: ["me", "mentorImport"] }
-  );
-}
-
-export async function _importMentor(
   mentor: string,
   json: MentorExportJson,
   replacedMentorDataChanges: ReplacedMentorDataChanges,

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -31,6 +31,7 @@ import {
   UploadTask,
   UploadProcessAsyncJob,
   ImportTask,
+  ReplacedMentorDataChanges,
 } from "types";
 import { SearchParams } from "hooks/graphql/use-with-data-connection";
 import {
@@ -1641,12 +1642,17 @@ export async function importMentor(
 export async function _importMentor(
   mentor: string,
   json: MentorExportJson,
+  replacedMentorDataChanges: ReplacedMentorDataChanges,
   accessToken: string
 ): Promise<MentorGQL> {
   const data = new FormData();
   data.append(
     "body",
-    JSON.stringify({ mentor: mentor, mentorExportJson: json })
+    JSON.stringify({
+      mentor: mentor,
+      mentorExportJson: json,
+      replacedMentorDataChanges: replacedMentorDataChanges,
+    })
   );
   const result = await uploadRequest.post("/transfer/mentor/", data, {
     headers: {

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1654,7 +1654,5 @@ export async function _importMentor(
       Authorization: `Bearer ${accessToken}`,
     },
   });
-  console.log("result from import mentor call");
-  console.log(result);
   return getDataFromAxiosResponse(result, "");
 }

--- a/client/src/components/import-export/icons.tsx
+++ b/client/src/components/import-export/icons.tsx
@@ -4,7 +4,7 @@ Permission to use, copy, modify, and distribute this software and its documentat
 
 The full terms of this copyright and license should always be found in the root directory of this software deliverable as "license.txt" and if these terms are not found with this software, please contact the USC Stevens Center for the full license.
 */
-import React from "react";
+import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core";
 import {
   Add as AddIcon,
@@ -25,7 +25,7 @@ const useStyles = makeStyles(() => ({
 export function ChangeIcon<T>(props: {
   preview: ImportPreview<T>;
 }): JSX.Element {
-  const { preview } = props;
+  const [preview] = useState<ImportPreview<T>>(props.preview);
   const classes = useStyles();
   const editType = preview.editType;
 

--- a/client/src/components/import-export/import-answer.tsx
+++ b/client/src/components/import-export/import-answer.tsx
@@ -132,14 +132,18 @@ export default function AnswerImport(props: {
                   fontWeight: !newAnswerChosen ? "normal" : "bold",
                 }}
               >
-                {newTranscript ?  `${newTranscript.substring(0, 200)}${newTranscript.length > 200 ? "..." : ""}` : "--no transcript--" }
+                {newTranscript
+                  ? `${newTranscript.substring(0, 200)}${
+                      newTranscript.length > 200 ? "..." : ""
+                    }`
+                  : "--no transcript--"}
               </Typography>
               <Button
                 variant="contained"
                 style={{
                   backgroundColor: "lightblue",
                   padding: 0,
-                  textTransform:"none",
+                  textTransform: "none",
                   marginTop: "5px",
                   marginBottom: "5px",
                   width: "150px",
@@ -152,9 +156,9 @@ export default function AnswerImport(props: {
                   }
                 }}
               >
-                {
-                  newAnswerChosen ? "Switch to old answer" : "Switch to new answer"
-                }
+                {newAnswerChosen
+                  ? "Switch to old answer"
+                  : "Switch to new answer"}
               </Button>
               <Typography
                 align="left"
@@ -164,7 +168,11 @@ export default function AnswerImport(props: {
                   fontWeight: newAnswerChosen ? "normal" : "bold",
                 }}
               >
-                { originalTranscript ?  `${originalTranscript.substring(0, 200)}${originalTranscript.length > 200 ? "..." : ""}` : "--no transcript--"}
+                {originalTranscript
+                  ? `${originalTranscript.substring(0, 200)}${
+                      originalTranscript.length > 200 ? "..." : ""
+                    }`
+                  : "--no transcript--"}
               </Typography>
             </>
           ) : (
@@ -179,6 +187,7 @@ export default function AnswerImport(props: {
           <>
             {answerPendingRemoval ? "Flagged for removal" : ""}
             <Button
+              data-cy="remove-old-answer"
               variant="contained"
               style={{
                 backgroundColor: answerPendingRemoval ? "lightblue" : "red",

--- a/client/src/components/import-export/import-answer.tsx
+++ b/client/src/components/import-export/import-answer.tsx
@@ -132,19 +132,17 @@ export default function AnswerImport(props: {
                   fontWeight: !newAnswerChosen ? "normal" : "bold",
                 }}
               >
-                NEW:{" "}
-                {`${newTranscript.substring(0, 200)}${
-                  newTranscript.length > 200 ? "..." : ""
-                }`}
+                {newTranscript ?  `${newTranscript.substring(0, 200)}${newTranscript.length > 200 ? "..." : ""}` : "--no transcript--" }
               </Typography>
               <Button
                 variant="contained"
                 style={{
                   backgroundColor: "lightblue",
                   padding: 0,
+                  textTransform:"none",
                   marginTop: "5px",
                   marginBottom: "5px",
-                  width: "20px",
+                  width: "150px",
                 }}
                 onClick={() => {
                   if (newAnswerChosen && originalAnswer) {
@@ -154,7 +152,9 @@ export default function AnswerImport(props: {
                   }
                 }}
               >
-                Switch
+                {
+                  newAnswerChosen ? "Switch to old answer" : "Switch to new answer"
+                }
               </Button>
               <Typography
                 align="left"
@@ -164,10 +164,7 @@ export default function AnswerImport(props: {
                   fontWeight: newAnswerChosen ? "normal" : "bold",
                 }}
               >
-                OLD:{" "}
-                {`${originalTranscript.substring(0, 200)}${
-                  originalTranscript.length > 200 ? "..." : ""
-                }`}
+                { originalTranscript ?  `${originalTranscript.substring(0, 200)}${originalTranscript.length > 200 ? "..." : ""}` : "--no transcript--"}
               </Typography>
             </>
           ) : (

--- a/client/src/components/import-export/import-answer.tsx
+++ b/client/src/components/import-export/import-answer.tsx
@@ -6,6 +6,7 @@ The full terms of this copyright and license should always be found in the root 
 */
 import React, { useState } from "react";
 import {
+  Button,
   Card,
   Collapse,
   IconButton,
@@ -39,18 +40,30 @@ const useStyles = makeStyles(() => ({
     display: "flex",
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "flex-start",
+    justifyContent: "space-evenly",
+    width: "100%",
   },
 }));
 
 export default function AnswerImport(props: {
   preview: ImportPreview<AnswerGQL>;
+  oldAnswersToRemove: AnswerGQL[];
+  toggleRemoveOldAnswer: (a: AnswerGQL) => void;
+  replaceNewAnswer: (a: AnswerGQL) => void;
 }): JSX.Element {
   const classes = useStyles();
   const [isExpanded, setIsExpanded] = useState(false);
-  const { preview } = props;
+  const {
+    preview,
+    oldAnswersToRemove,
+    toggleRemoveOldAnswer,
+    replaceNewAnswer,
+  } = props;
   const { editType, importData: answer, curData: curAnswer } = preview;
-  const transcript = answer?.transcript || curAnswer?.transcript || "";
+  const [originalAnswer] = useState<AnswerGQL | undefined>(curAnswer);
+  const [newAnswer] = useState<AnswerGQL | undefined>(answer);
+  const originalTranscript = originalAnswer?.transcript || "";
+  const newTranscript = newAnswer?.transcript || "";
   if (!(answer || curAnswer)) {
     return <div />;
   }
@@ -79,27 +92,115 @@ export default function AnswerImport(props: {
         curData: m,
       });
     });
-
+  const answerPendingRemoval = Boolean(
+    oldAnswersToRemove.find(
+      (oldAnswer) => oldAnswer.question._id === curAnswer?.question._id
+    )
+  );
+  const changedAnswer = Boolean(
+    originalAnswer &&
+      newAnswer &&
+      originalAnswer?.transcript !== newAnswer?.transcript
+  );
+  const newAnswerChosen = answer?.transcript !== originalAnswer?.transcript;
   return (
-    <Card data-cy="answer" className={classes.root}>
+    <Card
+      data-cy="answer"
+      className={classes.root}
+      style={{ opacity: answerPendingRemoval ? 0.5 : 1 }}
+    >
       <div className={classes.row}>
         <ChangeIcon preview={preview} />
-        <div style={{ marginRight: 10, width: "100%" }}>
+        <div
+          style={{
+            marginRight: 10,
+            width: "100%",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
           <Typography align="left" variant="body1">
             {answer?.question?.question || curAnswer?.question?.question}
           </Typography>
-          <Typography align="left" variant="caption">
-            {`${transcript.substring(0, 100)}${
-              transcript.length > 100 ? "..." : ""
-            }`}
-          </Typography>
+          {changedAnswer ? (
+            <>
+              <Typography
+                align="left"
+                variant="caption"
+                style={{
+                  opacity: !newAnswerChosen ? 0.5 : 1,
+                  fontWeight: !newAnswerChosen ? "normal" : "bold",
+                }}
+              >
+                NEW:{" "}
+                {`${newTranscript.substring(0, 200)}${
+                  newTranscript.length > 200 ? "..." : ""
+                }`}
+              </Typography>
+              <Button
+                variant="contained"
+                style={{
+                  backgroundColor: "lightblue",
+                  padding: 0,
+                  marginTop: "5px",
+                  marginBottom: "5px",
+                  width: "20px",
+                }}
+                onClick={() => {
+                  if (newAnswerChosen && originalAnswer) {
+                    replaceNewAnswer(originalAnswer);
+                  } else if (!newAnswerChosen && newAnswer) {
+                    replaceNewAnswer(newAnswer);
+                  }
+                }}
+              >
+                Switch
+              </Button>
+              <Typography
+                align="left"
+                variant="caption"
+                style={{
+                  opacity: newAnswerChosen ? 0.5 : 1,
+                  fontWeight: newAnswerChosen ? "normal" : "bold",
+                }}
+              >
+                OLD:{" "}
+                {`${originalTranscript.substring(0, 200)}${
+                  originalTranscript.length > 200 ? "..." : ""
+                }`}
+              </Typography>
+            </>
+          ) : (
+            <Typography align="left" variant="caption">
+              {`${(newTranscript || originalTranscript).substring(0, 200)}${
+                (newTranscript || originalTranscript).length > 200 ? "..." : ""
+              }`}
+            </Typography>
+          )}
         </div>
+        {editType === EditType.OLD_ANSWER && curAnswer ? (
+          <>
+            {answerPendingRemoval ? "Flagged for removal" : ""}
+            <Button
+              variant="contained"
+              style={{
+                backgroundColor: answerPendingRemoval ? "lightblue" : "red",
+                padding: "3px",
+                fontWeight: "bold",
+              }}
+              onClick={() => {
+                toggleRemoveOldAnswer(curAnswer);
+              }}
+            >
+              {answerPendingRemoval ? "Undo" : "Remove"}
+            </Button>
+          </>
+        ) : undefined}
         <IconButton
           data-cy="toggle"
           size="small"
           aria-expanded={isExpanded}
           onClick={() => setIsExpanded(!isExpanded)}
-          style={{ position: "absolute", right: 20 }}
         >
           <ExpandMoreIcon
             style={{

--- a/client/src/components/import-export/import-in-progress.tsx
+++ b/client/src/components/import-export/import-in-progress.tsx
@@ -1,0 +1,159 @@
+/*
+This software is Copyright ©️ 2020 The University of Southern California. All Rights Reserved. 
+Permission to use, copy, modify, and distribute this software and its documentation for educational, research and non-profit purposes, without fee, and without a written agreement is hereby granted, provided that the above copyright notice and subject to the full license file found in the root of this software deliverable. Permission to make commercial use of this software may be obtained by contacting:  USC Stevens Center for Innovation University of Southern California 1150 S. Olive Street, Suite 2300, Los Angeles, CA 90115, USA Email: accounting@stevens.usc.edu
+
+The full terms of this copyright and license should always be found in the root directory of this software deliverable as "license.txt" and if these terms are not found with this software, please contact the USC Stevens Center for the full license.
+*/
+
+import React from "react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  makeStyles,
+  Typography,
+} from "@material-ui/core";
+import {
+  Autorenew,
+  HourglassEmptyTwoTone,
+  ErrorOutline,
+  CheckBox,
+} from "@material-ui/icons";
+import {
+  ImportGraphQLUpdate,
+  ImportS3VideoMigrate,
+  ImportTask,
+  ImportTaskStatus,
+} from "types";
+import { useWithLogin } from "store/slices/login/useWithLogin";
+
+const useStyles = makeStyles((theme) => ({
+  progressIcon: {
+    animation: "$spin 3000ms",
+    // animationName: "spin",
+    animationDuration: "1000ms",
+    animationIterationCount: "infinite",
+    animationTimingFunction: "linear",
+  },
+  "@keyframes spin": {
+    from: {
+      transform: "rotate(0deg)",
+    },
+    to: {
+      transform: "rotate(360deg)",
+    },
+  },
+}));
+
+export default function ImportInProgressDialog(props: {
+  importInProgress: boolean;
+  importTask: ImportTask;
+}): JSX.Element {
+  const { logout } = useWithLogin();
+  const classes = useStyles();
+  function getIcon(status: ImportTaskStatus) {
+    switch (status) {
+      case ImportTaskStatus.QUEUED:
+        return <HourglassEmptyTwoTone />;
+      case ImportTaskStatus.IN_PROGRESS:
+        // TODO: make this one rotate 360 with css
+        return <Autorenew className={classes.progressIcon} />;
+      case ImportTaskStatus.FAILED:
+        return <ErrorOutline style={{ color: "red" }} />;
+      case ImportTaskStatus.DONE:
+        return <CheckBox style={{ color: "green" }} />;
+    }
+  }
+
+  function GraphQLUpdateDisplay(graphQLTask: ImportGraphQLUpdate) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          borderBottom: "1px black solid",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ width: "40%" }}>GraphQL Update</div>
+          <div style={{ width: "40%" }}>{graphQLTask.status}</div>
+          <div style={{ width: "10%" }}>{getIcon(graphQLTask.status)}</div>
+        </div>
+
+        {graphQLTask.errorMessage ? (
+          <div style={{ color: "red", margin: "10px" }}>
+            {graphQLTask.errorMessage}
+          </div>
+        ) : undefined}
+      </div>
+    );
+  }
+
+  function VideoMigrationDisplay(videoMigration: ImportS3VideoMigrate) {
+    const migrationTasks = videoMigration.answerMediaMigrations;
+    const completeTasks = migrationTasks.filter(
+      (task) => task.status === ImportTaskStatus.DONE
+    );
+    const failedTasks = migrationTasks.filter(
+      (task) => task.status === ImportTaskStatus.FAILED
+    );
+    return (
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ width: "40%" }}>s3 Media Transfer</div>
+          <div style={{ width: "40%" }}>
+            {videoMigration.status === ImportTaskStatus.QUEUED
+              ? "Queued"
+              : `${completeTasks.length} / ${migrationTasks.length} Transferred`}
+          </div>
+          <div style={{ width: "10%" }}>{getIcon(videoMigration.status)}</div>
+        </div>
+
+        {failedTasks.length ? (
+          <div>
+            <h4 style={{ color: "red", margin: "5px" }}>
+              {`${failedTasks.length} Failed Transfer(s):`}
+            </h4>
+            {failedTasks.map((task) => {
+              return (
+                <div>
+                  {`${task.question} failed with message: ${task.errorMessage}`}
+                </div>
+              );
+            })}
+          </div>
+        ) : undefined}
+      </div>
+    );
+  }
+
+  return (
+    <Dialog open={props.importInProgress} fullWidth={true} maxWidth={"sm"}>
+      <DialogContent>
+        <Typography
+          style={{ fontWeight: "bold", fontSize: "18px", marginBottom: "10px" }}
+        >
+          Mentor import in progress
+        </Typography>
+        {GraphQLUpdateDisplay(props.importTask.graphQLUpdate)}
+        {VideoMigrationDisplay(props.importTask.s3VideoMigrate)}
+
+        <Button onClick={() => logout()} style={{ marginTop: "20px" }}>
+          Logout
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/import-export/import-in-progress.tsx
+++ b/client/src/components/import-export/import-in-progress.tsx
@@ -65,7 +65,6 @@ export default function ImportInProgressDialog(props: {
       case ImportTaskStatus.QUEUED:
         return <HourglassEmptyTwoTone />;
       case ImportTaskStatus.IN_PROGRESS:
-        // TODO: make this one rotate 360 with css
         return <Autorenew className={classes.progressIcon} />;
       case ImportTaskStatus.FAILED:
         return <ErrorOutline style={{ color: "red" }} />;

--- a/client/src/components/import-export/import-in-progress.tsx
+++ b/client/src/components/import-export/import-in-progress.tsx
@@ -29,7 +29,7 @@ import { useWithLogin } from "store/slices/login/useWithLogin";
 import useActiveMentor from "store/slices/mentor/useActiveMentor";
 import { isImportComplete } from "hooks/graphql/use-with-import-status";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   progressIcon: {
     animation: "$spin 3000ms",
     // animationName: "spin",
@@ -137,7 +137,7 @@ export default function ImportInProgressDialog(props: {
             </h4>
             {failedTasks.map((task) => {
               return (
-                <div>
+                <div key={task.question}>
                   {`${task.question} failed with message: ${task.errorMessage}`}
                 </div>
               );

--- a/client/src/components/import-export/import-in-progress.tsx
+++ b/client/src/components/import-export/import-in-progress.tsx
@@ -154,7 +154,12 @@ export default function ImportInProgressDialog(props: {
   }
 
   return (
-    <Dialog open={open} fullWidth={true} maxWidth={"sm"}>
+    <Dialog
+      data-cy="import-progress-dialog"
+      open={open}
+      fullWidth={true}
+      maxWidth={"sm"}
+    >
       <DialogContent>
         <Typography
           style={{ fontWeight: "bold", fontSize: "18px", marginBottom: "10px" }}
@@ -166,11 +171,19 @@ export default function ImportInProgressDialog(props: {
         {VideoMigrationDisplay(props.importTask.s3VideoMigrate)}
 
         {isImportComplete(props.importTask) ? (
-          <Button onClick={() => onClose()} style={{ marginTop: "20px" }}>
+          <Button
+            data-cy="close-button"
+            onClick={() => onClose()}
+            style={{ marginTop: "20px" }}
+          >
             Close
           </Button>
         ) : (
-          <Button onClick={() => logout()} style={{ marginTop: "20px" }}>
+          <Button
+            data-cy="logout-button"
+            onClick={() => logout()}
+            style={{ marginTop: "20px" }}
+          >
             Logout
           </Button>
         )}

--- a/client/src/components/import-export/import-question.tsx
+++ b/client/src/components/import-export/import-question.tsx
@@ -4,19 +4,18 @@ Permission to use, copy, modify, and distribute this software and its documentat
 
 The full terms of this copyright and license should always be found in the root directory of this software deliverable as "license.txt" and if these terms are not found with this software, please contact the USC Stevens Center for the full license.
 */
-import React, { useState } from "react";
+import React from "react";
 import {
   Card,
-  IconButton,
   ListItemText,
   makeStyles,
   TextField,
   Typography,
 } from "@material-ui/core";
-import { FindReplace as FindReplaceIcon } from "@material-ui/icons";
 import { Autocomplete } from "@material-ui/lab";
-import { Question, ImportPreview, EditType } from "types";
+import { Question, ImportPreview, EditType, Category } from "types";
 import { ChangeIcon } from "./icons";
+import { SubjectQuestionGQL } from "types-gql";
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -37,14 +36,22 @@ const useStyles = makeStyles(() => ({
 
 export default function QuestionImport(props: {
   preview: ImportPreview<Question>;
+  subjectQuestion?: SubjectQuestionGQL;
   questions: Question[];
+  categories: Category[];
   mapQuestion: (curQuestion: Question, newQuestion: Question) => void;
+  mapCategory: (questionBeingReplaced: Question, category: Category) => void;
 }): JSX.Element {
   const classes = useStyles();
-  const [questionSearch, setQuestionSearch] = useState<Question>();
-  const { preview, questions, mapQuestion } = props;
+  const {
+    preview,
+    questions,
+    mapQuestion,
+    mapCategory,
+    categories,
+    subjectQuestion,
+  } = props;
   const { editType, importData: question, curData: curQuestion } = preview;
-
   return (
     <Card data-cy="question" className={classes.root}>
       <div className={classes.row}>
@@ -57,39 +64,49 @@ export default function QuestionImport(props: {
           style={{ position: "absolute", right: 20 }}
         >
           {editType === EditType.CREATED && questions.length ? (
-            <Autocomplete
-              key={preview.importData?._id}
-              data-cy="question-input"
-              options={questions}
-              getOptionLabel={(option: Question) => option.question}
-              onChange={(e, v) => {
-                setQuestionSearch(v || undefined);
-              }}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  style={{ width: 300 }}
-                  variant="outlined"
-                  placeholder="Remap to existing question?"
-                />
-              )}
-              renderOption={(option) => (
-                <ListItemText primary={option.question} />
-              )}
-            />
-          ) : undefined}
-          {editType === EditType.CREATED && questions.length ? (
-            <IconButton
-              data-cy="replace"
-              size="small"
-              onClick={() => {
-                if (question && questionSearch) {
-                  mapQuestion(question, questionSearch);
-                }
-              }}
-            >
-              <FindReplaceIcon />
-            </IconButton>
+            <>
+              <Autocomplete
+                data-cy="category-remap-input"
+                options={categories}
+                getOptionLabel={(option: Category) => option.name}
+                onChange={(e, v) => {
+                  v && question && mapCategory(question, v);
+                }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    style={{ width: 300 }}
+                    variant="outlined"
+                    placeholder={
+                      subjectQuestion?.category?.name || "Add a category?"
+                    }
+                  />
+                )}
+                renderOption={(option) => (
+                  <ListItemText primary={option.name} />
+                )}
+              />
+              <Autocomplete
+                key={preview.importData?._id}
+                data-cy="question-input"
+                options={questions}
+                getOptionLabel={(option: Question) => option.question}
+                onChange={(e, v) => {
+                  question && v && mapQuestion(question, v);
+                }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    style={{ width: 300 }}
+                    variant="outlined"
+                    placeholder="Remap to existing question?"
+                  />
+                )}
+                renderOption={(option) => (
+                  <ListItemText primary={option.question} />
+                )}
+              />
+            </>
           ) : undefined}
         </div>
       </div>

--- a/client/src/components/import-export/import-question.tsx
+++ b/client/src/components/import-export/import-question.tsx
@@ -58,6 +58,7 @@ export default function QuestionImport(props: {
         >
           {editType === EditType.CREATED && questions.length ? (
             <Autocomplete
+              key={preview.importData?._id}
               data-cy="question-input"
               options={questions}
               getOptionLabel={(option: Question) => option.question}

--- a/client/src/components/import-export/import-question.tsx
+++ b/client/src/components/import-export/import-question.tsx
@@ -13,9 +13,9 @@ import {
   Typography,
 } from "@material-ui/core";
 import { Autocomplete } from "@material-ui/lab";
-import { Question, ImportPreview, EditType, Category } from "types";
+import { Question, ImportPreview, EditType, Category, Topic } from "types";
 import { ChangeIcon } from "./icons";
-import { SubjectQuestionGQL } from "types-gql";
+import { SubjectGQL, SubjectQuestionGQL } from "types-gql";
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -39,8 +39,15 @@ export default function QuestionImport(props: {
   subjectQuestion?: SubjectQuestionGQL;
   questions: Question[];
   categories: Category[];
+  topics: Topic[];
+  subjects: SubjectGQL[];
   mapQuestion: (curQuestion: Question, newQuestion: Question) => void;
   mapCategory: (questionBeingReplaced: Question, category: Category) => void;
+  mapTopic: (questionBeingUpdated: Question, topic: Topic) => void;
+  mapQuestionToSubject: (
+    questionBeingMapped: Question,
+    targetSubject: SubjectGQL
+  ) => void;
 }): JSX.Element {
   const classes = useStyles();
   const {
@@ -48,12 +55,16 @@ export default function QuestionImport(props: {
     questions,
     mapQuestion,
     mapCategory,
+    mapTopic,
+    mapQuestionToSubject,
     categories,
     subjectQuestion,
+    subjects,
+    topics,
   } = props;
   const { editType, importData: question, curData: curQuestion } = preview;
   return (
-    <Card data-cy="question" className={classes.root}>
+    <Card key={question?._id} data-cy="question" className={classes.root}>
       <div className={classes.row}>
         <ChangeIcon preview={preview} />
         <Typography align="left" variant="body1" style={{ marginRight: 10 }}>
@@ -63,32 +74,78 @@ export default function QuestionImport(props: {
           className={classes.row}
           style={{ position: "absolute", right: 20 }}
         >
+          {editType === EditType.CREATED ? (
+            <Autocomplete
+              data-cy="remap-question-subject-input"
+              options={subjects}
+              getOptionLabel={(option: SubjectGQL) => option.name}
+              onChange={(e, v) => {
+                v && question && mapQuestionToSubject(question, v);
+              }}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  style={{ width: 300 }}
+                  variant="outlined"
+                  placeholder={"Map to a subject?"}
+                />
+              )}
+              renderOption={(option) => <ListItemText primary={option.name} />}
+            />
+          ) : undefined}
           {editType === EditType.CREATED && questions.length ? (
             <>
-              <Autocomplete
-                data-cy="category-remap-input"
-                options={categories}
-                getOptionLabel={(option: Category) => option.name}
-                onChange={(e, v) => {
-                  v && question && mapCategory(question, v);
-                }}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    style={{ width: 300 }}
-                    variant="outlined"
-                    placeholder={
-                      subjectQuestion?.category?.name || "Add a category?"
-                    }
-                  />
-                )}
-                renderOption={(option) => (
-                  <ListItemText primary={option.name} />
-                )}
-              />
+              {categories.length ? (
+                <Autocomplete
+                  data-cy="category-remap-input"
+                  options={categories}
+                  getOptionLabel={(option: Category) => option.name}
+                  onChange={(e, v) => {
+                    v && question && mapCategory(question, v);
+                  }}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      style={{ width: 300 }}
+                      variant="outlined"
+                      placeholder={
+                        subjectQuestion?.category?.name || "Add a category?"
+                      }
+                    />
+                  )}
+                  renderOption={(option) => (
+                    <ListItemText primary={option.name} />
+                  )}
+                />
+              ) : undefined}
+              {topics.length ? (
+                <Autocomplete
+                  data-cy="topic-remap-input"
+                  options={topics}
+                  getOptionLabel={(option: Topic) => option.name}
+                  onChange={(e, v) => {
+                    v && question && mapTopic(question, v);
+                  }}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      style={{ width: 300 }}
+                      variant="outlined"
+                      placeholder={
+                        subjectQuestion?.topics?.length
+                          ? subjectQuestion.topics[0].name
+                          : "Map to a topic?"
+                      }
+                    />
+                  )}
+                  renderOption={(option) => (
+                    <ListItemText primary={option.name} />
+                  )}
+                />
+              ) : undefined}
               <Autocomplete
                 key={preview.importData?._id}
-                data-cy="question-input"
+                data-cy="question-remap-input"
                 options={questions}
                 getOptionLabel={(option: Question) => option.question}
                 onChange={(e, v) => {
@@ -99,7 +156,7 @@ export default function QuestionImport(props: {
                     {...params}
                     style={{ width: 300 }}
                     variant="outlined"
-                    placeholder="Remap to existing question?"
+                    placeholder="Map to existing question?"
                   />
                 )}
                 renderOption={(option) => (

--- a/client/src/components/import-export/import-question.tsx
+++ b/client/src/components/import-export/import-question.tsx
@@ -56,7 +56,7 @@ export default function QuestionImport(props: {
           className={classes.row}
           style={{ position: "absolute", right: 20 }}
         >
-          {editType === EditType.CREATED ? (
+          {editType === EditType.CREATED && questions.length ? (
             <Autocomplete
               data-cy="question-input"
               options={questions}
@@ -77,7 +77,7 @@ export default function QuestionImport(props: {
               )}
             />
           ) : undefined}
-          {editType === EditType.CREATED ? (
+          {editType === EditType.CREATED && questions.length ? (
             <IconButton
               data-cy="replace"
               size="small"

--- a/client/src/components/import-export/import-question.tsx
+++ b/client/src/components/import-export/import-question.tsx
@@ -6,6 +6,7 @@ The full terms of this copyright and license should always be found in the root 
 */
 import React from "react";
 import {
+  Button,
   Card,
   ListItemText,
   makeStyles,
@@ -41,8 +42,10 @@ export default function QuestionImport(props: {
   categories: Category[];
   topics: Topic[];
   subjects: SubjectGQL[];
+  oldQuestionsToRemove: Question[];
   mapQuestion: (curQuestion: Question, newQuestion: Question) => void;
   mapCategory: (questionBeingReplaced: Question, category: Category) => void;
+  toggleRemoveOldFollowup: (q: Question) => void;
   mapTopic: (questionBeingUpdated: Question, topic: Topic) => void;
   mapQuestionToSubject: (
     questionBeingMapped: Question,
@@ -60,11 +63,21 @@ export default function QuestionImport(props: {
     categories,
     subjectQuestion,
     subjects,
+    toggleRemoveOldFollowup,
+    oldQuestionsToRemove,
     topics,
   } = props;
   const { editType, importData: question, curData: curQuestion } = preview;
+  const questionPendingRemoval = Boolean(
+    oldQuestionsToRemove.find((qToRemove) => qToRemove._id === curQuestion?._id)
+  );
   return (
-    <Card key={question?._id} data-cy="question" className={classes.root}>
+    <Card
+      key={question?._id}
+      data-cy="question"
+      className={classes.root}
+      style={{ opacity: questionPendingRemoval ? 0.5 : 1 }}
+    >
       <div className={classes.row}>
         <ChangeIcon preview={preview} />
         <Typography align="left" variant="body1" style={{ marginRight: 10 }}>
@@ -163,6 +176,24 @@ export default function QuestionImport(props: {
                   <ListItemText primary={option.question} />
                 )}
               />
+            </>
+          ) : undefined}
+          {editType === EditType.OLD_FOLLOWUP && curQuestion ? (
+            <>
+              {questionPendingRemoval ? "Flagged for removal" : ""}
+              <Button
+                variant="contained"
+                style={{
+                  backgroundColor: questionPendingRemoval ? "lightblue" : "red",
+                  padding: "3px",
+                  margin: "3px",
+                }}
+                onClick={() => {
+                  toggleRemoveOldFollowup(curQuestion);
+                }}
+              >
+                {questionPendingRemoval ? "Undo" : "Remove"}
+              </Button>
             </>
           ) : undefined}
         </div>

--- a/client/src/components/import-export/import-question.tsx
+++ b/client/src/components/import-export/import-question.tsx
@@ -71,6 +71,7 @@ export default function QuestionImport(props: {
   const questionPendingRemoval = Boolean(
     oldQuestionsToRemove.find((qToRemove) => qToRemove._id === curQuestion?._id)
   );
+  const inputWidth = 300;
   return (
     <Card
       key={question?._id}
@@ -98,7 +99,7 @@ export default function QuestionImport(props: {
               renderInput={(params) => (
                 <TextField
                   {...params}
-                  style={{ width: 300 }}
+                  style={{ width: 200 }}
                   variant="outlined"
                   placeholder={"Map to a subject?"}
                 />
@@ -119,7 +120,7 @@ export default function QuestionImport(props: {
                   renderInput={(params) => (
                     <TextField
                       {...params}
-                      style={{ width: 300 }}
+                      style={{ width: inputWidth }}
                       variant="outlined"
                       placeholder={
                         subjectQuestion?.category?.name || "Add a category?"
@@ -142,7 +143,7 @@ export default function QuestionImport(props: {
                   renderInput={(params) => (
                     <TextField
                       {...params}
-                      style={{ width: 300 }}
+                      style={{ width: inputWidth }}
                       variant="outlined"
                       placeholder={
                         subjectQuestion?.topics?.length
@@ -167,7 +168,7 @@ export default function QuestionImport(props: {
                 renderInput={(params) => (
                   <TextField
                     {...params}
-                    style={{ width: 300 }}
+                    style={{ width: inputWidth }}
                     variant="outlined"
                     placeholder="Map to existing question?"
                   />
@@ -182,6 +183,7 @@ export default function QuestionImport(props: {
             <>
               {questionPendingRemoval ? "Flagged for removal" : ""}
               <Button
+                data-cy="remove-old-question"
                 variant="contained"
                 style={{
                   backgroundColor: questionPendingRemoval ? "lightblue" : "red",

--- a/client/src/components/import-export/import-subject.tsx
+++ b/client/src/components/import-export/import-subject.tsx
@@ -139,10 +139,9 @@ export default function SubjectImport(props: {
     });
 
   const questions: ImportPreview<Question>[] = [];
-
   // for all questions of the importing subject
   subject?.questions?.forEach((q) => {
-    // Check if the imported question already exists in this subject
+    // Check if the imported subject question already exists in this subject
     const curQuestion = curSubject?.questions?.find(
       (qq) =>
         !q.question.mentor &&

--- a/client/src/components/import-export/import-subject.tsx
+++ b/client/src/components/import-export/import-subject.tsx
@@ -161,7 +161,7 @@ export default function SubjectImport(props: {
   });
 
   // subject is the importingSubject
-  // curSubject is the subject being replaced, which may have some other mentor specific q's visible
+  // curSubject is the subject being replaced
 
   // Check if the current subject has some mentor specific questions that are not in the new subject
   curSubject?.questions

--- a/client/src/components/import-export/import-subject.tsx
+++ b/client/src/components/import-export/import-subject.tsx
@@ -30,6 +30,7 @@ import { ChangeIcon } from "./icons";
 import { SubjectGQL } from "types-gql";
 import QuestionImport from "./import-question";
 import { useWithQuestions } from "hooks/graphql/use-with-questions";
+import useActiveMentor from "store/slices/mentor/useActiveMentor";
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -56,6 +57,8 @@ export default function SubjectImport(props: {
   mapSubject: (curSubject: SubjectGQL, newSubject: SubjectGQL) => void;
   mapQuestion: (curQuestion: Question, newQuestion: Question) => void;
 }): JSX.Element {
+  const { getData } = useActiveMentor();
+  const mentorId = getData((m) => m.data?._id || "");
   const classes = useStyles();
   const [isExpanded, setIsExpanded] = useState(false);
   const [subjectSearch, setSubjectSearch] = useState<SubjectGQL>();
@@ -129,10 +132,15 @@ export default function SubjectImport(props: {
     });
   });
 
+  // subject is the importingSubject
+  // curSubject is the subject being replaced, which may have some other mentor specific q's visible
   curSubject?.questions
     ?.filter(
       (qq) =>
-        !subject?.questions?.find((q) => q.question?._id === qq.question?._id)
+        !subject?.questions?.find(
+          (q) => q.question?._id === qq.question?._id
+        ) &&
+        (!qq.question.mentor || qq.question.mentor == mentorId)
     )
     .forEach((q) => {
       questions.push({

--- a/client/src/components/import-export/import-view.tsx
+++ b/client/src/components/import-export/import-view.tsx
@@ -51,6 +51,8 @@ export default function ImportView(props: {
     onConfirmImport: confirmImport,
     onMapSubject: mapSubject,
     onMapQuestion: mapQuestion,
+    onMapCategory: mapCategory,
+    onSaveSubjectName: saveSubjectName,
     isUpdating,
   } = props.useImportExport;
   const { data: subjects } = useWithSubjects();
@@ -104,6 +106,8 @@ export default function ImportView(props: {
                 subjects={subjects?.edges.map((e) => e.node) || []}
                 mapSubject={mapSubject}
                 mapQuestion={mapQuestion}
+                mapCategory={mapCategory}
+                saveSubjectName={saveSubjectName}
                 previewQuestions={importPreview.questions}
               />
             );

--- a/client/src/components/import-export/import-view.tsx
+++ b/client/src/components/import-export/import-view.tsx
@@ -23,6 +23,7 @@ import { UseWithImportExport } from "hooks/graphql/use-with-import-export";
 import SubjectImport from "./import-subject";
 import AnswerImport from "./import-answer";
 import { LoadingDialog } from "components/dialog";
+import { EditType } from "types";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -54,8 +55,15 @@ export default function ImportView(props: {
     onMapCategory: mapCategory,
     onMapTopic: mapTopic,
     onSaveSubjectName: saveSubjectName,
+    oldQuestionsToRemove,
+    toggleRemoveOldAnswer,
+    oldAnswersToRemove,
+    onToggleRemoveAllOldAnswers,
+    onReplaceNewAnswer: replaceNewAnswer,
+    toggleRemoveOldFollowup: toggleRemoveOldFollowup,
     onMapQuestionToSubject: mapQuestionToSubject,
     isUpdating,
+    onToggleReplaceEntireMentor: replaceEntireMentor,
   } = props.useImportExport;
   const { data: subjects } = useWithSubjects();
 
@@ -63,6 +71,17 @@ export default function ImportView(props: {
     return <LoadingDialog title={isUpdating ? "Loading..." : ""} />;
   }
 
+  const newAnswers = importPreview?.answers?.filter(
+    (a) => a.editType === EditType.ADDED || a.editType === EditType.CREATED
+  );
+
+  const changedAnswers = importPreview?.answers?.filter(
+    (a) => a.editType === EditType.NONE
+  );
+
+  const oldAnswers = importPreview?.answers?.filter(
+    (a) => a.editType === EditType.OLD_ANSWER
+  );
   return (
     <Dialog fullScreen open={Boolean(importPreview)} onClose={cancelImport}>
       <AppBar>
@@ -91,6 +110,17 @@ export default function ImportView(props: {
       </AppBar>
       <div className={classes.toolbar} /> {/* create space below app bar */}
       <DialogContent className={classes.root}>
+        <Button
+          style={{
+            backgroundColor: "#ff8080",
+            padding: "3px",
+            fontWeight: "bold",
+            borderRadius: "10px",
+          }}
+          onClick={() => replaceEntireMentor()}
+        >
+          Toggle Remove All Previous Mentor Data
+        </Button>
         <Typography style={{ marginBottom: 10 }}>
           The following changes will be made to your mentor if you import this
           JSON:
@@ -109,6 +139,8 @@ export default function ImportView(props: {
                 mapSubject={mapSubject}
                 mapQuestion={mapQuestion}
                 mapCategory={mapCategory}
+                toggleRemoveOldFollowup={toggleRemoveOldFollowup}
+                oldQuestionsToRemove={oldQuestionsToRemove}
                 mapTopic={mapTopic}
                 mapQuestionToSubject={mapQuestionToSubject}
                 saveSubjectName={saveSubjectName}
@@ -118,14 +150,64 @@ export default function ImportView(props: {
           })}
         </List>
         <p />
-        <List
-          data-cy="answers"
-          className={classes.list}
-          subheader={<ListSubheader>My Answers</ListSubheader>}
-        >
-          {importPreview?.answers?.map((a, i) => {
-            return <AnswerImport key={`answer-${i}`} preview={a} />;
-          })}
+        <List data-cy="answers" className={classes.list}>
+          <List data-cy="changed-answers">
+            Changed Answers
+            {changedAnswers.map((a, i) => {
+              return (
+                <AnswerImport
+                  key={`answer-${i}`}
+                  preview={a}
+                  oldAnswersToRemove={oldAnswersToRemove}
+                  toggleRemoveOldAnswer={toggleRemoveOldAnswer}
+                  replaceNewAnswer={replaceNewAnswer}
+                />
+              );
+            })}
+          </List>
+          <List data-cy="old-answers">
+            Old Answers
+            {
+              <Button
+                style={{
+                  position: "absolute",
+                  right: 50,
+                  top: 0,
+                  padding: "5px",
+                  backgroundColor: "lightblue",
+                  fontWeight: "bold",
+                }}
+                onClick={() => onToggleRemoveAllOldAnswers()}
+              >
+                Toggle All
+              </Button>
+            }
+            {oldAnswers.map((a, i) => {
+              return (
+                <AnswerImport
+                  key={`answer-${i}`}
+                  preview={a}
+                  oldAnswersToRemove={oldAnswersToRemove}
+                  toggleRemoveOldAnswer={toggleRemoveOldAnswer}
+                  replaceNewAnswer={replaceNewAnswer}
+                />
+              );
+            })}
+          </List>
+          <List data-cy="new-answers">
+            New Followup Answers
+            {newAnswers.map((a, i) => {
+              return (
+                <AnswerImport
+                  key={`answer-${i}`}
+                  preview={a}
+                  oldAnswersToRemove={oldAnswersToRemove}
+                  toggleRemoveOldAnswer={toggleRemoveOldAnswer}
+                  replaceNewAnswer={replaceNewAnswer}
+                />
+              );
+            })}
+          </List>
         </List>
       </DialogContent>
       <LoadingDialog title={isUpdating ? "Loading..." : ""} />

--- a/client/src/components/import-export/import-view.tsx
+++ b/client/src/components/import-export/import-view.tsx
@@ -43,6 +43,8 @@ const useStyles = makeStyles((theme) => ({
 
 export default function ImportView(props: {
   useImportExport: UseWithImportExport;
+  mentorName: string;
+  mentorId: string;
 }): JSX.Element {
   const classes = useStyles();
   const {
@@ -66,7 +68,7 @@ export default function ImportView(props: {
     onToggleReplaceEntireMentor: replaceEntireMentor,
   } = props.useImportExport;
   const { data: subjects } = useWithSubjects();
-
+  const { mentorName, mentorId } = props;
   if (!importedJson || !importPreview) {
     return <LoadingDialog title={isUpdating ? "Loading..." : ""} />;
   }
@@ -110,6 +112,13 @@ export default function ImportView(props: {
       </AppBar>
       <div className={classes.toolbar} /> {/* create space below app bar */}
       <DialogContent className={classes.root}>
+        <Typography data-cy="mentor-name">
+          <p>
+            Mentor being replaced: {<br />}
+            {mentorName ? `Name: ${mentorName}` : ""} {<br />}
+            {mentorId ? `Mentor ID: ${mentorId}` : ""}
+          </p>
+        </Typography>
         <Button
           data-cy="remove-all-old-mentor-data"
           style={{

--- a/client/src/components/import-export/import-view.tsx
+++ b/client/src/components/import-export/import-view.tsx
@@ -24,6 +24,7 @@ import { UseWithImportExport } from "hooks/graphql/use-with-import-export";
 import SubjectImport from "./import-subject";
 import QuestionImport from "./import-question";
 import AnswerImport from "./import-answer";
+import { LoadingDialog } from "components/dialog";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -52,14 +53,12 @@ export default function ImportView(props: {
     onConfirmImport: confirmImport,
     onMapSubject: mapSubject,
     onMapQuestion: mapQuestion,
-    importInProgress,
-    importTask,
+    isUpdating,
   } = props.useImportExport;
   const { data: subjects } = useWithSubjects();
-  const { data: questions } = useWithQuestions();
 
   if (!importedJson || !importPreview) {
-    return <div />;
+    return <LoadingDialog title={isUpdating ? "Loading..." : ""} />;
   }
 
   return (
@@ -106,23 +105,8 @@ export default function ImportView(props: {
                 preview={s}
                 subjects={subjects?.edges.map((e) => e.node) || []}
                 mapSubject={mapSubject}
-              />
-            );
-          })}
-        </List>
-        <p />
-        <List
-          data-cy="questions"
-          className={classes.list}
-          subheader={<ListSubheader>My Questions</ListSubheader>}
-        >
-          {importPreview?.questions?.map((q, i) => {
-            return (
-              <QuestionImport
-                key={`question-${i}`}
-                preview={q}
-                questions={questions?.edges.map((e) => e.node) || []}
                 mapQuestion={mapQuestion}
+                previewQuestions={importPreview.questions}
               />
             );
           })}

--- a/client/src/components/import-export/import-view.tsx
+++ b/client/src/components/import-export/import-view.tsx
@@ -52,7 +52,9 @@ export default function ImportView(props: {
     onMapSubject: mapSubject,
     onMapQuestion: mapQuestion,
     onMapCategory: mapCategory,
+    onMapTopic: mapTopic,
     onSaveSubjectName: saveSubjectName,
+    onMapQuestionToSubject: mapQuestionToSubject,
     isUpdating,
   } = props.useImportExport;
   const { data: subjects } = useWithSubjects();
@@ -107,6 +109,8 @@ export default function ImportView(props: {
                 mapSubject={mapSubject}
                 mapQuestion={mapQuestion}
                 mapCategory={mapCategory}
+                mapTopic={mapTopic}
+                mapQuestionToSubject={mapQuestionToSubject}
                 saveSubjectName={saveSubjectName}
                 previewQuestions={importPreview.questions}
               />

--- a/client/src/components/import-export/import-view.tsx
+++ b/client/src/components/import-export/import-view.tsx
@@ -111,6 +111,7 @@ export default function ImportView(props: {
       <div className={classes.toolbar} /> {/* create space below app bar */}
       <DialogContent className={classes.root}>
         <Button
+          data-cy="remove-all-old-mentor-data"
           style={{
             backgroundColor: "#ff8080",
             padding: "3px",
@@ -195,7 +196,7 @@ export default function ImportView(props: {
             })}
           </List>
           <List data-cy="new-answers">
-            New Followup Answers
+            New Answers
             {newAnswers.map((a, i) => {
               return (
                 <AnswerImport

--- a/client/src/components/import-export/import-view.tsx
+++ b/client/src/components/import-export/import-view.tsx
@@ -19,10 +19,8 @@ import {
 } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
 import { useWithSubjects } from "hooks/graphql/use-with-subjects";
-import { useWithQuestions } from "hooks/graphql/use-with-questions";
 import { UseWithImportExport } from "hooks/graphql/use-with-import-export";
 import SubjectImport from "./import-subject";
-import QuestionImport from "./import-question";
 import AnswerImport from "./import-answer";
 import { LoadingDialog } from "components/dialog";
 
@@ -122,6 +120,7 @@ export default function ImportView(props: {
           })}
         </List>
       </DialogContent>
+      <LoadingDialog title={isUpdating ? "Loading..." : ""} />
     </Dialog>
   );
 }

--- a/client/src/components/import-export/import-view.tsx
+++ b/client/src/components/import-export/import-view.tsx
@@ -52,6 +52,8 @@ export default function ImportView(props: {
     onConfirmImport: confirmImport,
     onMapSubject: mapSubject,
     onMapQuestion: mapQuestion,
+    importInProgress,
+    importTask,
   } = props.useImportExport;
   const { data: subjects } = useWithSubjects();
   const { data: questions } = useWithQuestions();

--- a/client/src/components/nav-bar.tsx
+++ b/client/src/components/nav-bar.tsx
@@ -48,6 +48,8 @@ import {
   areAllTasksDone,
   isATaskCancelled,
 } from "hooks/graphql/upload-status-helpers";
+import { useWithImportStatus } from "hooks/graphql/use-with-import-status";
+import ImportInProgressDialog from "./import-export/import-in-progress";
 
 const useStyles = makeStyles((theme) => ({
   toolbar: theme.mixins.toolbar,
@@ -290,6 +292,8 @@ export function NavBar(props: {
     onNav,
     onBack,
   } = props;
+  const importStatus = useWithImportStatus();
+  const { importTask } = importStatus;
   const numUploadsInProgress =
     uploads?.filter(
       (upload) => !areAllTasksDone(upload) && !isATaskCancelled(upload)
@@ -369,6 +373,9 @@ export function NavBar(props: {
         <Toolbar />
         <NavMenu classes={classes} mentorId={props.mentorId} onNav={onNav} />
       </SwipeableDrawer>
+      {importTask ? (
+        <ImportInProgressDialog importTask={importTask} />
+      ) : undefined}
       <div className={classes.toolbar} /> {/* create space below app bar */}
     </div>
   );

--- a/client/src/hooks/graphql/use-with-data-connection.ts
+++ b/client/src/hooks/graphql/use-with-data-connection.ts
@@ -43,11 +43,12 @@ const defaultSearchParams: SearchParams = {
 
 export function useWithDataConnection<T>(
   fetch: () => Promise<Connection<T>>,
-  initalSearchParams?: SearchParams
+  initalSearchParams?: Partial<SearchParams>
 ): UseDataConnection<T> {
-  const [searchParams, setSearchParams] = useState<SearchParams>(
-    initalSearchParams || defaultSearchParams
-  );
+  const [searchParams, setSearchParams] = useState<SearchParams>({
+    ...defaultSearchParams,
+    ...initalSearchParams,
+  });
   const { data, isLoading, error, editData, saveData, reloadData } =
     useWithData<Connection<T>>(fetch);
 

--- a/client/src/hooks/graphql/use-with-import-export.tsx
+++ b/client/src/hooks/graphql/use-with-import-export.tsx
@@ -287,14 +287,12 @@ export function useWithImportExport(): UseWithImportExport {
     // We need to check if an answer document exists for the question that is being mapped to and remove it
     // We need to also check if there is an answer document with "new" data that was part of the question that was mapped
     //    and update the question to point to the target answer.
-    console.log("here1");
     const replacementIdx = preview.answers.findIndex(
       (previewAnswer) =>
         (previewAnswer.curData || previewAnswer.importData)?.question._id ===
         replacement._id
     );
     if (replacementIdx !== -1) {
-      console.log("here2");
       preview.answers.splice(replacementIdx, 1);
     }
     const newAnswerIdx = preview.answers.findIndex(
@@ -303,13 +301,21 @@ export function useWithImportExport(): UseWithImportExport {
         question._id
     );
     if (newAnswerIdx !== -1) {
-      console.log("here3");
       // There is some answer document that has the answer data for the imported question that got mapped
       const importData = preview.answers[newAnswerIdx].importData;
       if (importData) {
         //There is some legitimate data that needs to be mapped to the target question
         importData.question = replacement;
-        console.log("import data reached");
+      }
+    }
+    // Also remove the question from the imported subjects question list
+    for (const s of preview.subjects) {
+      const previewSubjectQuestionIdx =
+        s.importData?.questions.findIndex(
+          (q) => q.question._id === question._id
+        ) || -1;
+      if (previewSubjectQuestionIdx !== -1) {
+        s.importData?.questions.splice(previewSubjectQuestionIdx, 1);
       }
     }
     setImportPreview(preview);
@@ -586,18 +592,8 @@ export function useWithImportExport(): UseWithImportExport {
     if (
       !oldAnswersToRemove.find((a) => a.question._id === answer.question._id)
     ) {
-      console.log(
-        `couldn't find answer with question id ${
-          answer.question._id
-        } in list ${oldAnswersToRemove.map((a) => a.question._id)}`
-      );
       setOldAnswersToRemove(oldAnswersToRemove.concat(answer));
     } else {
-      console.log(
-        `found answer with question id ${
-          answer.question._id
-        } in list ${oldAnswersToRemove.map((a) => a.question._id)}`
-      );
       setOldAnswersToRemove(
         oldAnswersToRemove.filter((a) => a.question._id !== answer.question._id)
       );
@@ -648,9 +644,6 @@ export function useWithImportExport(): UseWithImportExport {
         oldAnswers.push(oldAnswerPreview.curData);
       }
     });
-    console.log(
-      `questions flagged for removal ${JSON.stringify(oldQuestions)}`
-    );
     if (
       oldQuestionsToRemove.length === oldQuestions.length &&
       oldAnswersToRemove.length === oldAnswers.length

--- a/client/src/hooks/graphql/use-with-import-export.tsx
+++ b/client/src/hooks/graphql/use-with-import-export.tsx
@@ -30,18 +30,18 @@ export interface UseWithImportExport {
   onMapSubject: (curSubject: SubjectGQL, newSubject: SubjectGQL) => void;
   onMapQuestion: (curQuestion: Question, newQuestion: Question) => void;
   importTask: ImportTask | undefined;
+  isUpdating: boolean;
 }
 
 export function useWithImportExport(): UseWithImportExport {
   const [importedJson, setImportJson] = useState<MentorExportJson>();
   const [importPreview, setImportPreview] = useState<MentorImportPreview>();
   const [isUpdating, setIsUpdating] = useState(false);
-  const { getData, loadMentor } = useActiveMentor();
+  const { getData } = useActiveMentor();
   const mentorId = getData((state) => state.data?._id);
   const mentorAnswers: Answer[] = getData((state) => state.data?.answers);
   const accessToken = useAppSelector((state) => state.login.accessToken);
-  const { importTask, importInProgress, setImportInProgress } =
-    useWithImportStatus();
+  const { importTask, setImportInProgress } = useWithImportStatus();
 
   async function onMentorExported(): Promise<void> {
     if (!mentorId || isUpdating) {
@@ -85,8 +85,7 @@ export function useWithImportExport(): UseWithImportExport {
     api._importMentor(mentorId, importedJson, accessToken).then(() => {
       setImportJson(undefined);
       setImportPreview(undefined);
-      setIsUpdating(true);
-      loadMentor();
+      setIsUpdating(false);
       setImportInProgress(true); //starts the polling
     });
   }
@@ -200,6 +199,7 @@ export function useWithImportExport(): UseWithImportExport {
     onMapSubject,
     onMapQuestion,
     importTask,
+    isUpdating,
   };
 }
 

--- a/client/src/hooks/graphql/use-with-import-export.tsx
+++ b/client/src/hooks/graphql/use-with-import-export.tsx
@@ -126,7 +126,7 @@ export function useWithImportExport(): UseWithImportExport {
     }
     setIsUpdating(true);
     api
-      ._importMentor(
+      .importMentor(
         mentorId,
         importedJson,
         getReplacedMentorChanges(),

--- a/client/src/hooks/graphql/use-with-import-export.tsx
+++ b/client/src/hooks/graphql/use-with-import-export.tsx
@@ -123,11 +123,26 @@ export function useWithImportExport(): UseWithImportExport {
     }
     // find and replace the "new" subject in import with the replacement subject
     const idx = subjects.findIndex((s) => s._id === subject._id);
+
     if (idx !== -1) {
-      subjects = copyAndSet(subjects, idx, replacement);
+      // The subject that was replaced may have had some questions that were overwritten by the replacement
+      // To handle this, we need to add it to the new subject
+      const subjectBeingReplaced = subjects[idx];
+      const newQuestions = subjectBeingReplaced.questions.filter(
+        (q) =>
+          !Boolean(
+            replacement.questions.find(
+              (rep_q) => rep_q.question._id === q.question._id
+            )
+          )
+      );
+      const replacementSubj: SubjectGQL = {
+        ...replacement,
+        questions: replacement.questions.concat(newQuestions),
+      };
+      subjects = copyAndSet(subjects, idx, replacementSubj);
     }
-    // TODO: if the subject that was replaced had some questions that were overwritten by the replacement
-    // we might need to remap them in imported questions and answers list
+
     updateImport({
       ...importedJson,
       subjects,

--- a/client/src/hooks/graphql/use-with-import-export.tsx
+++ b/client/src/hooks/graphql/use-with-import-export.tsx
@@ -29,7 +29,6 @@ export interface UseWithImportExport {
   onTransferMedia: () => void;
   onMapSubject: (curSubject: SubjectGQL, newSubject: SubjectGQL) => void;
   onMapQuestion: (curQuestion: Question, newQuestion: Question) => void;
-  importInProgress: boolean;
   importTask: ImportTask | undefined;
 }
 
@@ -185,7 +184,6 @@ export function useWithImportExport(): UseWithImportExport {
     onTransferMedia,
     onMapSubject,
     onMapQuestion,
-    importInProgress,
     importTask,
   };
 }

--- a/client/src/hooks/graphql/use-with-import-status.tsx
+++ b/client/src/hooks/graphql/use-with-import-status.tsx
@@ -63,7 +63,7 @@ export function useWithImportStatus(
   }, [mentorId, accessToken]);
 
   useInterval(
-    (isCancelled) => {
+    () => {
       if (!mentorId || !accessToken) {
         return;
       }

--- a/client/src/hooks/graphql/use-with-import-status.tsx
+++ b/client/src/hooks/graphql/use-with-import-status.tsx
@@ -29,7 +29,7 @@ export function isImportComplete(task: ImportTask) {
 }
 
 export function useWithImportStatus(
-  pollingInterval = 1000
+  pollingInterval = 10000
 ): UseWithImportStatus {
   const { state: loginState } = useWithLogin();
   const { getData } = useActiveMentor();

--- a/client/src/hooks/graphql/use-with-import-status.tsx
+++ b/client/src/hooks/graphql/use-with-import-status.tsx
@@ -1,0 +1,73 @@
+/*
+This software is Copyright ©️ 2020 The University of Southern California. All Rights Reserved. 
+Permission to use, copy, modify, and distribute this software and its documentation for educational, research and non-profit purposes, without fee, and without a written agreement is hereby granted, provided that the above copyright notice and subject to the full license file found in the root of this software deliverable. Permission to make commercial use of this software may be obtained by contacting:  USC Stevens Center for Innovation University of Southern California 1150 S. Olive Street, Suite 2300, Los Angeles, CA 90115, USA Email: accounting@stevens.usc.edu
+
+The full terms of this copyright and license should always be found in the root directory of this software deliverable as "license.txt" and if these terms are not found with this software, please contact the USC Stevens Center for the full license.
+*/
+import { fetchImportTask } from "api";
+import useInterval from "hooks/task/use-interval";
+import { useEffect, useState } from "react";
+import { useWithLogin } from "store/slices/login/useWithLogin";
+import useActiveMentor from "store/slices/mentor/useActiveMentor";
+import { ImportTask } from "types";
+
+export interface UseWithImportStatus {
+  importTask: ImportTask | undefined;
+  importInProgress: boolean;
+  setImportInProgress: (b: boolean) => void;
+}
+
+export function useWithImportStatus(
+  pollingInterval = 1000
+): UseWithImportStatus {
+  const { state: loginState } = useWithLogin();
+  const { getData } = useActiveMentor();
+  const mentorId = getData((state) => state.data?._id);
+  const [importTask, setImportTask] = useState<ImportTask>();
+  const [importInProgress, setImportInProgress] = useState<boolean>(false);
+  const accessToken = loginState.accessToken;
+
+  useEffect(() => {
+    let mounted = true;
+    if (!mentorId || !accessToken) {
+      return;
+    }
+    fetchImportTask(mentorId, accessToken)
+      .then((task) => {
+        if (!mounted) {
+          return;
+        }
+        setImportTask(task);
+        setImportInProgress(Boolean(task));
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [mentorId, accessToken]);
+
+  useInterval(
+    (isCancelled) => {
+      if (!mentorId || !accessToken) {
+        return;
+      }
+      fetchImportTask(mentorId, accessToken)
+        .then((task) => {
+          setImportTask(task);
+          setImportInProgress(Boolean(task));
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    },
+    importInProgress ? pollingInterval : null
+  );
+
+  return {
+    importTask,
+    importInProgress,
+    setImportInProgress,
+  };
+}

--- a/client/src/hooks/graphql/use-with-import-status.tsx
+++ b/client/src/hooks/graphql/use-with-import-status.tsx
@@ -48,11 +48,10 @@ export function useWithImportStatus(
         if (!mounted) {
           return;
         }
-        if (isImportComplete(task)) {
+        setImportTask(task);
+        setImportInProgress(Boolean(task));
+        if (task && isImportComplete(task)) {
           deleteImportTask(accessToken, mentorId);
-        } else {
-          setImportTask(task);
-          setImportInProgress(Boolean(task));
         }
       })
       .catch((err) => {

--- a/client/src/hooks/graphql/use-with-import-status.tsx
+++ b/client/src/hooks/graphql/use-with-import-status.tsx
@@ -17,7 +17,7 @@ export interface UseWithImportStatus {
   setImportInProgress: (b: boolean) => void;
 }
 
-export function isImportComplete(task: ImportTask) {
+export function isImportComplete(task: ImportTask): boolean {
   const gqlUpdateStatus = task.graphQLUpdate.status;
   const mediaTransferStatus = task.s3VideoMigrate.status;
   return (
@@ -29,7 +29,7 @@ export function isImportComplete(task: ImportTask) {
 }
 
 export function useWithImportStatus(
-  pollingInterval = 10000
+  pollingInterval = 1000
 ): UseWithImportStatus {
   const { state: loginState } = useWithLogin();
   const { getData } = useActiveMentor();

--- a/client/src/hooks/graphql/use-with-questions.tsx
+++ b/client/src/hooks/graphql/use-with-questions.tsx
@@ -14,7 +14,7 @@ import {
 } from "./use-with-data-connection";
 
 export function useWithQuestions(
-  initalSearchParams?: SearchParams
+  initalSearchParams?: Partial<SearchParams>
 ): UseDataConnection<Question> {
   const {
     data,

--- a/client/src/hooks/graphql/use-with-review-answer-state.tsx
+++ b/client/src/hooks/graphql/use-with-review-answer-state.tsx
@@ -130,7 +130,7 @@ export function useWithReviewAnswerState(
         _blocks.push({
           subject: subject._id,
           category: undefined,
-          name: subject.name,
+          name: `${subject.name} (Uncategorized)`,
           description: subject.description,
           questions: uncategorizedQuestions,
         });
@@ -163,7 +163,7 @@ export function useWithReviewAnswerState(
           _blocks.push({
             subject: subject._id,
             category: undefined,
-            name: subject.name,
+            name: `${subject.name} (Uncategorized)`,
             description: subject.description,
             questions: uncategorizedQuestions,
           });

--- a/client/src/pages/importexport.tsx
+++ b/client/src/pages/importexport.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles(() => ({
 function ImportPage(): JSX.Element {
   const classes = useStyles();
   const useImportExport = useWithImportExport();
-  const { importInProgress, importTask } = useImportExport;
+  const { importTask } = useImportExport;
   const { getData } = useActiveMentor();
 
   const mentorId = getData((state) => state.data?._id);
@@ -40,10 +40,7 @@ function ImportPage(): JSX.Element {
     <div className={classes.root}>
       <NavBar title="Export Mentor" mentorId={mentorId} />
       {importTask ? (
-        <ImportInProgressDialog
-          importInProgress={importInProgress}
-          importTask={importTask}
-        />
+        <ImportInProgressDialog importTask={importTask} />
       ) : undefined}
       <ImportView useImportExport={useImportExport} />
       <div style={{ padding: 10 }}>

--- a/client/src/pages/importexport.tsx
+++ b/client/src/pages/importexport.tsx
@@ -35,7 +35,7 @@ function ImportPage(): JSX.Element {
   if (!mentorId || !mentorAnswers) {
     return <div />;
   }
-  const needsTransfer = mentorAnswers.some((a) => a.hasUntransferredMedia);
+
   return (
     <div className={classes.root}>
       <NavBar title="Export Mentor" mentorId={mentorId} />
@@ -67,16 +67,6 @@ function ImportPage(): JSX.Element {
             }}
           />
         </Button>
-        {needsTransfer ? (
-          <Button
-            data-cy="transfer-media"
-            variant="contained"
-            onClick={useImportExport.onTransferMedia}
-            style={{ marginLeft: 10 }}
-          >
-            Transfer Answers
-          </Button>
-        ) : undefined}
       </div>
     </div>
   );

--- a/client/src/pages/importexport.tsx
+++ b/client/src/pages/importexport.tsx
@@ -5,7 +5,7 @@ Permission to use, copy, modify, and distribute this software and its documentat
 The full terms of this copyright and license should always be found in the root directory of this software deliverable as "license.txt" and if these terms are not found with this software, please contact the USC Stevens Center for the full license.
 */
 import React from "react";
-import { Button } from "@material-ui/core";
+import { Button, CircularProgress, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 
 import NavBar from "components/nav-bar";
@@ -27,13 +27,19 @@ function ImportPage(): JSX.Element {
   const classes = useStyles();
   const useImportExport = useWithImportExport();
   const { importTask } = useImportExport;
-  const { getData } = useActiveMentor();
+  const { getData, isLoading } = useActiveMentor();
 
   const mentorId = getData((state) => state.data?._id);
+  const mentorName = getData((state) => state.data?.name) || "";
   const mentorAnswers: Answer[] = getData((state) => state.data?.answers);
 
-  if (!mentorId || !mentorAnswers) {
-    return <div />;
+  if (!mentorId || !mentorAnswers || isLoading) {
+    return (
+      <div>
+        <NavBar title="Mentor Studio" mentorId="" />
+        <CircularProgress />
+      </div>
+    );
   }
 
   return (
@@ -42,8 +48,19 @@ function ImportPage(): JSX.Element {
       {importTask ? (
         <ImportInProgressDialog importTask={importTask} />
       ) : undefined}
-      <ImportView useImportExport={useImportExport} />
+      <ImportView
+        useImportExport={useImportExport}
+        mentorName={mentorName}
+        mentorId={mentorId}
+      />
       <div style={{ padding: 10 }}>
+        <Typography data-cy="mentor-name">
+          <p>
+            Mentor being replaced: {<br />}
+            {mentorName ? `Name: ${mentorName}` : ""} {<br />}
+            {mentorId ? `Mentor ID: ${mentorId}` : ""}
+          </p>
+        </Typography>
         <Button
           data-cy="download-mentor"
           color="primary"

--- a/client/src/pages/importexport.tsx
+++ b/client/src/pages/importexport.tsx
@@ -31,6 +31,7 @@ function ImportPage(): JSX.Element {
 
   const mentorId = getData((state) => state.data?._id);
   const mentorName = getData((state) => state.data?.name) || "";
+  const mentorTitle = getData((state) => state.data?.title) || "";
   const mentorAnswers: Answer[] = getData((state) => state.data?.answers);
 
   if (!mentorId || !mentorAnswers || isLoading) {
@@ -58,6 +59,7 @@ function ImportPage(): JSX.Element {
           <p>
             Mentor being replaced: {<br />}
             {mentorName ? `Name: ${mentorName}` : ""} {<br />}
+            {mentorTitle ? `Title: ${mentorTitle}` : ""} {<br />}
             {mentorId ? `Mentor ID: ${mentorId}` : ""}
           </p>
         </Typography>

--- a/client/src/pages/importexport.tsx
+++ b/client/src/pages/importexport.tsx
@@ -14,6 +14,7 @@ import { useWithImportExport } from "hooks/graphql/use-with-import-export";
 import withAuthorizationOnly from "hooks/wrap-with-authorization-only";
 import useActiveMentor from "store/slices/mentor/useActiveMentor";
 import { Answer } from "types";
+import ImportInProgressDialog from "components/import-export/import-in-progress";
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -25,6 +26,7 @@ const useStyles = makeStyles(() => ({
 function ImportPage(): JSX.Element {
   const classes = useStyles();
   const useImportExport = useWithImportExport();
+  const { importInProgress, importTask } = useImportExport;
   const { getData } = useActiveMentor();
 
   const mentorId = getData((state) => state.data?._id);
@@ -37,6 +39,12 @@ function ImportPage(): JSX.Element {
   return (
     <div className={classes.root}>
       <NavBar title="Export Mentor" mentorId={mentorId} />
+      {importTask ? (
+        <ImportInProgressDialog
+          importInProgress={importInProgress}
+          importTask={importTask}
+        />
+      ) : undefined}
       <ImportView useImportExport={useImportExport} />
       <div style={{ padding: 10 }}>
         <Button

--- a/client/src/pages/users.tsx
+++ b/client/src/pages/users.tsx
@@ -28,6 +28,7 @@ import {
   KeyboardArrowLeft as KeyboardArrowLeftIcon,
   KeyboardArrowRight as KeyboardArrowRightIcon,
   Launch as LaunchIcon,
+  ImportExport,
 } from "@material-ui/icons";
 
 import { ColumnDef, ColumnHeader } from "components/column-header";
@@ -205,6 +206,18 @@ function UserItem(props: {
             className={styles.normalButton}
           >
             <LaunchIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip style={{ margin: 10 }} title="Import" arrow>
+          <IconButton
+            data-cy="import-button"
+            onClick={() => {
+              switchActiveMentor(edge.node.defaultMentor._id);
+              navigate("/importexport");
+            }}
+            className={styles.normalButton}
+          >
+            <ImportExport />
           </IconButton>
         </Tooltip>
         <Tooltip style={{ margin: 10 }} title="Export Mentor" arrow>

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -191,6 +191,28 @@ interface ExportedMentorInfo {
   mentorType: string;
 }
 
+export enum MentorDataTypes {
+  QUESTION = "QUESTION",
+  ANSWER = "ANSWER",
+  SUBJECT = "SUBJECT",
+  TOPIC = "TOPIC",
+  CATEGORY = "CATEGORY",
+}
+
+export interface ChangedMentorData<T> {
+  editType: EditType;
+  data: T;
+}
+
+export interface ReplacedMentorDataChanges {
+  questionChanges: ChangedMentorData<Question>[];
+  answerChanges: ChangedMentorData<AnswerGQL>[];
+  // topics: ChangedMentorData<Topic>[];
+  // categories: ChangedMentorData<Category>[];
+  // answers: ChangedMentorData<Answer>[];
+  // subjects: ChangedMentorData<Subject>[];
+}
+
 export interface MentorExportJson {
   id: string;
   mentorInfo: ExportedMentorInfo;
@@ -245,6 +267,8 @@ export enum EditType {
   ADDED = "ADDED",
   REMOVED = "REMOVED",
   CREATED = "CREATED",
+  OLD_FOLLOWUP = "OLD_FOLLOWUP",
+  OLD_ANSWER = "OLD_ANSWER",
 }
 
 export enum LoginStatus {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -6,7 +6,7 @@ The full terms of this copyright and license should always be found in the root 
 */
 
 import { CancelTokenSource } from "axios";
-import { AnswerGQL, SubjectGQL } from "types-gql";
+import { AnswerGQL, SubjectGQL, UserQuestionGQL } from "types-gql";
 
 export interface Config {
   googleClientId: string;
@@ -215,6 +215,7 @@ export interface MentorExportJson {
   subjects: SubjectGQL[];
   questions: Question[];
   answers: AnswerGQL[];
+  userQuestions: UserQuestionGQL[];
 }
 
 export interface ImportPreview<T> {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -207,10 +207,6 @@ export interface ChangedMentorData<T> {
 export interface ReplacedMentorDataChanges {
   questionChanges: ChangedMentorData<Question>[];
   answerChanges: ChangedMentorData<AnswerGQL>[];
-  // topics: ChangedMentorData<Topic>[];
-  // categories: ChangedMentorData<Category>[];
-  // answers: ChangedMentorData<Answer>[];
-  // subjects: ChangedMentorData<Subject>[];
 }
 
 export interface MentorExportJson {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -180,8 +180,20 @@ export interface VideoInfo {
   transcript: string;
 }
 
+interface ExportedMentorInfo {
+  name: string;
+  firstName: string;
+  title: string;
+  email: string;
+  thumbnail: string;
+  allowContact: boolean;
+  defaultSubject: string;
+  mentorType: string;
+}
+
 export interface MentorExportJson {
   id: string;
+  mentorInfo: ExportedMentorInfo;
   subjects: SubjectGQL[];
   questions: Question[];
   answers: AnswerGQL[];
@@ -308,4 +320,32 @@ export enum MediaType {
 export enum MediaTag {
   WEB = "web",
   MOBILE = "mobile",
+}
+
+export enum ImportTaskStatus {
+  QUEUED = "QUEUED",
+  IN_PROGRESS = "IN_PROGRESS",
+  FAILED = "FAILED",
+  DONE = "DONE",
+}
+
+export interface ImportGraphQLUpdate {
+  status: ImportTaskStatus;
+  errorMessage: string;
+}
+
+export interface ImportAnswerMediaMigrations {
+  status: ImportTaskStatus;
+  question: string;
+  errorMessage: string;
+}
+
+export interface ImportS3VideoMigrate {
+  status: ImportTaskStatus;
+  answerMediaMigrations: ImportAnswerMediaMigrations[];
+}
+
+export interface ImportTask {
+  graphQLUpdate: ImportGraphQLUpdate;
+  s3VideoMigrate: ImportS3VideoMigrate;
 }

--- a/cypress/cypress/fixtures/imports/import-preview.ts
+++ b/cypress/cypress/fixtures/imports/import-preview.ts
@@ -253,11 +253,11 @@ export const importPreview = {
       },
     },
     {
-      editType: "REMOVED",
+      editType: "OLD_FOLLOWUP",
       importData: null,
       curData: {
         _id: "q5",
-        question: "Removed Question 5",
+        question: "Old followup Question 5",
       },
     },
   ],
@@ -313,14 +313,14 @@ export const importPreview = {
       curData: null,
     },
     {
-      editType: "REMOVED",
+      editType: "OLD_ANSWER",
       importData: null,
       curData: {
-        transcript: "Removed Answer 5",
+        transcript: "Old Answer 5",
         status: "COMPLETE",
         question: {
           _id: "q5",
-          question: "Removed Question 5",
+          question: "Old Question 5",
         },
       },
     },

--- a/cypress/cypress/fixtures/mentor/clint_new.ts
+++ b/cypress/cypress/fixtures/mentor/clint_new.ts
@@ -16,7 +16,7 @@ export const mentor: Mentor = {
   _id: "clintanderson",
   name: "Clint Anderson",
   firstName: "",
-  title: "",
+  title: "The Original Clint",
   mentorType: MentorType.VIDEO,
   lastTrainedAt: null,
   questions: [],

--- a/cypress/cypress/fixtures/mentor/clint_new.ts
+++ b/cypress/cypress/fixtures/mentor/clint_new.ts
@@ -14,7 +14,7 @@ import {
 
 export const mentor: Mentor = {
   _id: "clintanderson",
-  name: "",
+  name: "Clint Anderson",
   firstName: "",
   title: "",
   mentorType: MentorType.VIDEO,

--- a/cypress/cypress/integration/home.spec.ts
+++ b/cypress/cypress/integration/home.spec.ts
@@ -27,7 +27,7 @@ describe("My Mentor Page", () => {
     cy.get("[data-cy=recording-blocks]").children().should("have.length", 4);
     cy.get("[data-cy=recording-blocks]").within(($blocks) => {
       cy.get("[data-cy=block-0]").within(($block) => {
-        cy.get("[data-cy=block-name]").should("have.text", "Background");
+        cy.get("[data-cy=block-name]").should("contain.text", "Background");
         cy.get("[data-cy=block-progress]").should("have.text", "1 / 1 (100%)");
         cy.get("[data-cy=block-description]").should(
           "have.text",
@@ -56,7 +56,10 @@ describe("My Mentor Page", () => {
         });
       });
       cy.get("[data-cy=block-2]").within(($block) => {
-        cy.get("[data-cy=block-name]").should("have.text", "Repeat After Me");
+        cy.get("[data-cy=block-name]").should(
+          "contain.text",
+          "Repeat After Me"
+        );
         cy.get("[data-cy=block-progress]").should("have.text", "2 / 2 (100%)");
         cy.get("[data-cy=block-description]").should(
           "have.text",
@@ -191,7 +194,7 @@ describe("My Mentor Page", () => {
     cy.get("[data-cy=recording-blocks]").children().should("have.length", 2);
     cy.get("[data-cy=recording-blocks]").within(($blocks) => {
       cy.get("[data-cy=block-0]").within(($block) => {
-        cy.get("[data-cy=block-name]").should("have.text", "Background");
+        cy.get("[data-cy=block-name]").should("contain.text", "Background");
         cy.get("[data-cy=block-progress]").should("have.text", "1 / 1 (100%)");
         cy.get("[data-cy=block-description]").should(
           "have.text",
@@ -261,7 +264,7 @@ describe("My Mentor Page", () => {
     cy.get("[data-cy=recording-blocks]").children().should("have.length", 2);
     cy.get("[data-cy=recording-blocks]").within(($blocks) => {
       cy.get("[data-cy=block-0]").within(($block) => {
-        cy.get("[data-cy=block-name]").should("have.text", "Background");
+        cy.get("[data-cy=block-name]").should("contain.text", "Background");
         cy.get("[data-cy=block-progress]").should("have.text", "1 / 1 (100%)");
         cy.get("[data-cy=block-description]").should(
           "have.text",
@@ -330,7 +333,7 @@ describe("My Mentor Page", () => {
     cy.get("[data-cy=select-subject]").contains("All Answers (4 / 5)");
     cy.get("[data-cy=recording-blocks]").within(($blocks) => {
       cy.get("[data-cy=block-0]").within(($block) => {
-        cy.get("[data-cy=block-name]").should("have.text", "Background");
+        cy.get("[data-cy=block-name]").should("contain.text", "Background");
         cy.get("[data-cy=answers-Complete]").within(($completeAnswers) => {
           cy.get("[data-cy=record-all]").trigger("mouseover").click();
         });
@@ -410,7 +413,10 @@ describe("My Mentor Page", () => {
     // cy.get("[data-cy=save-button]").should("be.disabled");
     cy.get("[data-cy=recording-blocks]").within(($blocks) => {
       cy.get("[data-cy=block-2]").within(($block) => {
-        cy.get("[data-cy=block-name]").should("have.text", "Repeat After Me");
+        cy.get("[data-cy=block-name]").should(
+          "contain.text",
+          "Repeat After Me"
+        );
         cy.get("[data-cy=answers-Incomplete]").within(($incompleteAnswers) => {
           cy.get("[data-cy=expand-btn]").trigger("mouseover").click();
           cy.get("[data-cy=add-question]").should("exist");

--- a/cypress/cypress/integration/import.spec.ts
+++ b/cypress/cypress/integration/import.spec.ts
@@ -86,6 +86,9 @@ describe("Import", { scrollBehavior: "center" }, () => {
     cy.contains("Export Mentor");
     cy.get("[data-cy=download-mentor]");
     cy.get("[data-cy=upload-mentor]");
+    cy.get("[data-cy=mentor-name]").contains("Mentor being replaced:");
+    cy.get("[data-cy=mentor-name]").contains("Name: Clint Anderson");
+    cy.get("[data-cy=mentor-name]").contains("Mentor ID: clintanderson");
   });
 
   it("Displays close when import complete", () => {
@@ -591,7 +594,7 @@ describe("Import", { scrollBehavior: "center" }, () => {
     });
   });
 
-  it.only("new questions can be mapped to existing questions", () => {
+  it("new questions can be mapped to existing questions", () => {
     cySetup(cy);
     cyMockDefault(cy, {
       mentor: clintNew,

--- a/cypress/cypress/integration/import.spec.ts
+++ b/cypress/cypress/integration/import.spec.ts
@@ -88,7 +88,7 @@ describe("Import", () => {
     cy.get("[data-cy=upload-mentor]");
   });
 
-  it.only("Import in progress UI", () => {
+  it.only("Displays close when import complete", () => {
     cySetup(cy);
     cyMockDefault(cy, {
       mentor: clintNew,
@@ -97,11 +97,10 @@ describe("Import", () => {
         mockGQL("ImportTask", {
           importTask: {
             graphQLUpdate: {
-              status: "FAILED",
-              errorMessage: "Failed because, that's why.",
+              status: "DONE",
             },
             s3VideoMigrate: {
-              status: "IN_PROGRESS",
+              status: "DONE",
               answerMediaMigrations: [
                 {
                   question: "q1",
@@ -113,17 +112,17 @@ describe("Import", () => {
                 },
                 {
                   question: "q3",
-                  status: "QUEUED",
+                  status: "DONE",
                 },
                 {
                   question: "q4",
-                  status: "FAILED",
-                  errorMessage: "HTTP error: 404",
+                  status: "DONE",
                 },
               ],
             },
           },
         }),
+        mockGQL("ImportTaskDelete", { me: { importTaskDelete: true } }),
       ],
     });
     cy.visit("/importexport");

--- a/cypress/cypress/integration/import.spec.ts
+++ b/cypress/cypress/integration/import.spec.ts
@@ -66,7 +66,7 @@ const questions: Connection<Partial<Question>> = {
 };
 
 describe("Import", { scrollBehavior: "center" }, () => {
-  it("shows page", () => {
+  it.only("shows page", () => {
     cySetup(cy);
     cyMockDefault(cy, {
       mentor: clintNew,

--- a/cypress/cypress/integration/import.spec.ts
+++ b/cypress/cypress/integration/import.spec.ts
@@ -88,7 +88,80 @@ describe("Import", () => {
     cy.get("[data-cy=upload-mentor]");
   });
 
-  it.only("Displays close when import complete", () => {
+  it("Displays close when import complete", () => {
+    cySetup(cy);
+    cyMockDefault(cy, {
+      mentor: clintNew,
+      subjects: [allSubjects],
+      gqlQueries: [
+        mockGQL("ImportTask", [
+          {
+            importTask: {
+              graphQLUpdate: {
+                status: "DONE",
+              },
+              s3VideoMigrate: {
+                status: "IN_PROGRESS",
+                answerMediaMigrations: [
+                  {
+                    question: "q1",
+                    status: "DONE",
+                  },
+                  {
+                    question: "q2",
+                    status: "DONE",
+                  },
+                  {
+                    question: "q3",
+                    status: "DONE",
+                  },
+                  {
+                    question: "q4",
+                    status: "IN_PROGRESS",
+                  },
+                ],
+              },
+            },
+          },
+          {
+            importTask: {
+              graphQLUpdate: {
+                status: "DONE",
+              },
+              s3VideoMigrate: {
+                status: "DONE",
+                answerMediaMigrations: [
+                  {
+                    question: "q1",
+                    status: "DONE",
+                  },
+                  {
+                    question: "q2",
+                    status: "DONE",
+                  },
+                  {
+                    question: "q3",
+                    status: "DONE",
+                  },
+                  {
+                    question: "q4",
+                    status: "DONE",
+                  },
+                ],
+              },
+            },
+          },
+        ]),
+        mockGQL("ImportTaskDelete", { me: { importTaskDelete: true } }),
+      ],
+    });
+    cy.visit("/importexport");
+    cy.get("[data-cy=import-progress-dialog]").within(($within) => {
+      cy.get("[data-cy=close-button]").should("be.visible");
+    });
+  });
+
+  it("Displays logout when import in progress", () => {
     cySetup(cy);
     cyMockDefault(cy, {
       mentor: clintNew,
@@ -100,7 +173,7 @@ describe("Import", () => {
               status: "DONE",
             },
             s3VideoMigrate: {
-              status: "DONE",
+              status: "IN_PROGRESS",
               answerMediaMigrations: [
                 {
                   question: "q1",
@@ -116,7 +189,7 @@ describe("Import", () => {
                 },
                 {
                   question: "q4",
-                  status: "DONE",
+                  status: "IN_PROGRESS",
                 },
               ],
             },
@@ -126,6 +199,49 @@ describe("Import", () => {
       ],
     });
     cy.visit("/importexport");
+    cy.get("[data-cy=import-progress-dialog]").within(($within) => {
+      cy.get("[data-cy=logout-button]").should("be.visible");
+    });
+  });
+
+  it.only("nav bar catches", () => {
+    cySetup(cy);
+    cyMockDefault(cy, {
+      mentor: clintNew,
+      subjects: [allSubjects],
+      gqlQueries: [
+        mockGQL("ImportTask", {
+          importTask: {
+            graphQLUpdate: {
+              status: "DONE",
+            },
+            s3VideoMigrate: {
+              status: "IN_PROGRESS",
+              answerMediaMigrations: [
+                {
+                  question: "q1",
+                  status: "DONE",
+                },
+                {
+                  question: "q2",
+                  status: "DONE",
+                },
+                {
+                  question: "q3",
+                  status: "DONE",
+                },
+                {
+                  question: "q4",
+                  status: "IN_PROGRESS",
+                },
+              ],
+            },
+          },
+        }),
+        mockGQL("ImportTaskDelete", { me: { importTaskDelete: true } }),
+      ],
+    });
+    cy.visit("/");
   });
 
   it("uploads import json and views import preview", () => {

--- a/cypress/cypress/integration/import.spec.ts
+++ b/cypress/cypress/integration/import.spec.ts
@@ -88,6 +88,47 @@ describe("Import", () => {
     cy.get("[data-cy=upload-mentor]");
   });
 
+  it.only("Import in progress UI", () => {
+    cySetup(cy);
+    cyMockDefault(cy, {
+      mentor: clintNew,
+      subjects: [allSubjects],
+      gqlQueries: [
+        mockGQL("ImportTask", {
+          importTask: {
+            graphQLUpdate: {
+              status: "FAILED",
+              errorMessage: "Failed because, that's why.",
+            },
+            s3VideoMigrate: {
+              status: "IN_PROGRESS",
+              answerMediaMigrations: [
+                {
+                  question: "q1",
+                  status: "DONE",
+                },
+                {
+                  question: "q2",
+                  status: "DONE",
+                },
+                {
+                  question: "q3",
+                  status: "QUEUED",
+                },
+                {
+                  question: "q4",
+                  status: "FAILED",
+                  errorMessage: "HTTP error: 404",
+                },
+              ],
+            },
+          },
+        }),
+      ],
+    });
+    cy.visit("/importexport");
+  });
+
   it("uploads import json and views import preview", () => {
     cySetup(cy);
     cyMockDefault(cy, {

--- a/cypress/cypress/integration/setup.spec.ts
+++ b/cypress/cypress/integration/setup.spec.ts
@@ -217,7 +217,7 @@ describe("Setup", () => {
     cyMockDefault(cy, {
       ...baseMock,
       mentor: [
-        setup0,
+        { ...setup0, name: "", title: "" },
         setup1,
         setup2,
         setup3,


### PR DESCRIPTION
- Importing a mentor is done entirely asynchronously, but you cannot use your mentor while an import is in progress.
- While importing a mentor, you are provided with updates on the progress of the import.
- When reviewing an import, you can move new questions around to new subjects, topics, and categories.
- You can also map new questions to pre-existing questions.
- You may choose to either keep or remove pre-existing mentor data.
- You may also choose to use either the pre-existing mentors or importing mentors answers for specific questions, where applicable.
- Anytime a mentor logs in, there is a check for an import in progress. If one is in progress, you are only able to view the progress of the import and log out.


Paired with:
GQL: https://github.com/mentorpal/mentor-graphql/pull/89
Upload: https://github.com/mentorpal/mentor-upload/pull/59